### PR TITLE
fix #22: OsgiUtil NPE, and make the whole test suite pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,22 +9,24 @@ Tonsias is an **Eclipse RCP / e4 desktop application** developed as an **Eclipse
 ## Commands
 
 ```bash
-./mvnw clean verify                              # compile every bundle, run all test bundles, build the product
+./mvnw clean verify                                    # compile every bundle, run all test bundles, build the product
 ./mvnw clean verify -Dmaven.test.failure.ignore=true   # keep going past failing tests to see every result
-./mvnw clean verify -pl de.tonsias.basis.osgi.test     # one test bundle (add -am to build its dependencies)
 ./mvnw clean verify -Dtest=KeyServiceImplTest          # a single test class
 ./mvnw clean verify -DskipTests                        # compile only
 ```
 
 Requires a JDK 24 in `JAVA_HOME` (the bundles' highest BREE). The wrapper downloads Maven itself; no local Maven install is needed.
 
+**Do not use `-pl` to build a single module.** Tycho derives the reactor from the OSGi manifests, not from Maven dependencies, so `-pl <module> -am` does not pull in the bundles that module requires and fails with "Missing requirement". Build the whole reactor and narrow with `-Dtest=` instead.
+
 ## Working in this repo
 
 - **Target platform**: `target-platform/target-platform.target` — Eclipse SDK 4.36 (2025-06) + Maven-sourced Guava 33.1.0, Gson 2.10.1, JUnit Jupiter 5.14.4, Mockito 5.23.0. It is the single source of truth for **both** the IDE and the Tycho build (consumed as an `eclipse-target-definition` module), so edit it rather than the poms when changing dependencies. Set it as the active target platform in the IDE before anything resolves.
 - **Run the app**: launch `de.tonsias.basis.product/tonsias.product` (E4Application, `-clearPersistedState`). Note `autoStart` config for `org.apache.felix.scr` and `org.eclipse.equinox.event` — DS and the event admin must be running or none of the services resolve. The Tycho test runtime configures the same two bundles for the same reason.
 - **Tests** are JUnit 5, and all three bundles need an OSGi runtime — run them as an **Eclipse JUnit Plug-in Test** in the IDE, or via `./mvnw verify`. What differs is how they obtain their subject:
-  - `BasicPreferenceServiceImplTest`, `KeyServiceImplTest`, `EventTreeNodeWrapperTest`, `InstanzViewLogicTest` construct it directly or with `@InjectMocks`, so they pass headlessly.
-  - `InstanzServiceImplTest` and `SingleValueServiceImplTest` call `OsgiUtil.getService(...)`. These **cannot pass in a plain DS runtime**: `InstanzServiceImpl` has a mandatory `@Reference IEventBrokerBridge`, and that bridge is only produced by `EventBrokerContextFunction`, an e4 `IContextFunction` that runs only when an `IEclipseContext` requests the key. Headless, nothing requests it, so the component never activates and `getService` returns `null`. They need a running e4 application context. `InstanzServiceImplTest` also writes real files to the instance location.
+  - Most tests construct it directly or with `@InjectMocks` and need nothing further.
+  - Tests that resolve real services through `OsgiUtil.getService(...)` (`InstanzServiceImplTest`, `SingleValueServiceImplTest`, `OsgiUtilTest`) must first call **`E4ServiceContext.prime()`** in `@BeforeEach`. `IEventBrokerBridge` and `IDeltaService` are not plain DS components — they come from `IContextFunction`s that only run when an `IEclipseContext` is asked for their key, and `ChangePropagationListener` is contributed as an e4 *addon* in `Application.e4xmi`. In the product the workbench triggers all three; headless nothing does, so without priming `InstanzServiceImpl`'s mandatory `@Reference IEventBrokerBridge` stays unsatisfied and the component never activates. Add `prime()` to any new test that touches real services.
+  - Those tests also need a **root instanz** (`_inse.getRoot()`), which `ModelView` creates at start-up in the product but nothing creates in a fresh test workspace. They write real files to the instance location (`target/work/data`), which is cleaned per run.
 - There are **no `.launch` files committed** — launch configs are local. If a launch config is missing, create one from the product / plug-in test wizard.
 - Java compliance levels are **inconsistent across bundles**, and the BREE in `MANIFEST.MF` frequently disagrees with the compliance in `.settings/org.eclipse.jdt.core.prefs` — `de.tonsias.basis.ui` declares `JavaSE-24` but compiles at 19, `de.tonsias.basis.logic` declares 24 but compiles at 22, while `de.tonsias.basis.osgi` and `de.tonsias.basis.model` are 19/19. A language feature usable in `de.tonsias.basis.logic` (22) will not compile in `de.tonsias.basis.osgi` (19). When adding a bundle, copy the settings from a sibling rather than accepting the wizard default. This is also why the Tycho build has to pin its resolution EE (see the comment in `pom.xml`); normalising the BREEs would let that pin go away.
 
@@ -110,6 +112,6 @@ Every feature follows this sequence end to end:
 
 Never commit directly to `main`.
 
-Step 5 is `./mvnw clean verify`. Note that this is **currently red on `main`** for pre-existing reasons (see [Working in this repo](#working-in-this-repo)): 18 of 44 tests fail — the 14 `OsgiUtil.getService` ones that need an e4 context, plus 4 in `logic.test` whose expectations have drifted from the production code. Compare against that baseline rather than assuming a red build is your fault, and never "fix" it by weakening assertions.
+Step 5 is `./mvnw clean verify`. The suite is **green on `main`** — 48 tests, all passing — so any failure is yours. Never "fix" one by weakening an assertion; if a test looks wrong, check it against the production code first (several once verified `post(..)` where the code had moved to `send(..)`).
 
 Step 6 places tests in the test bundle matching the layer under test: view logic → `de.tonsias.basis.logic.test`, services → `de.tonsias.basis.osgi.test`, delta view → `de.tonsias.delta.view.ui.test`. All three run inside OSGi; prefer `@InjectMocks`/direct construction over `OsgiUtil.getService(...)`, which only resolves under a running e4 context. A new bundle's internals need `x-friends` on its `Export-Package` before its test bundle can see them.

--- a/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.hamcrest;bundle-version="2.2.0",
  org.mockito.mockito-core;bundle-version="5.14.0",
  de.tonsias.basis.logic;bundle-version="1.0.0",
  de.tonsias.basis.osgi,
- de.tonsias.basis.model
+ de.tonsias.basis.model,
+ org.eclipse.e4.core.services;bundle-version="2.5.200"

--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/dialog/PreferencesDialogLogicTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/dialog/PreferencesDialogLogicTest.java
@@ -7,12 +7,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
@@ -26,8 +25,10 @@ import org.osgi.service.prefs.BackingStoreException;
 import de.tonsias.basis.logic.dialog.PreferencesDialogLogic;
 import de.tonsias.basis.logic.dialog.PreferencesDialogLogic.PreferenceFeature;
 import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
+import de.tonsias.basis.osgi.intf.IBasicPreferenceService.Key;
 import de.tonsias.basis.osgi.intf.IKeyService;
 import de.tonsias.basis.osgi.intf.non.service.IPreferences;
+import de.tonsias.basis.osgi.intf.non.service.IPreferences.PreferenceKeyEnum;
 
 @ExtendWith(MockitoExtension.class)
 public class PreferencesDialogLogicTest {
@@ -44,26 +45,28 @@ public class PreferencesDialogLogicTest {
 	@InjectMocks
 	PreferencesDialogLogic _logic;
 
+	/**
+	 * Every key of the preference yields one feature. The stored node has no value
+	 * for them, so each feature falls back to the key's init value.
+	 */
 	@Test
 	void testGetPreferences_validRequest() throws BackingStoreException {
 		doReturn(_basicPrefService).when(_map).get(anyString());
 		doReturn(IBasicPreferenceService.Key.values()).when(_basicPrefService).getKeys();
+		doReturn(mock(IEclipsePreferences.class)).when(_basicPrefService).getNode();
 
 		Collection<PreferenceFeature> preferences = _logic.getPreferences("");
 
 		assertThat(preferences.size(), is(3));
+		assertThat(preferences.stream().map(PreferenceFeature::value).toList(),
+				is(Arrays.stream(IBasicPreferenceService.Key.values()).map(Key::getInitValue).toList()));
 	}
 
+	/** A preference that declares no keys contributes no features. */
 	@Test
-	void testGetPreferences_error_emptyList() throws BackingStoreException {
+	void testGetPreferences_noKeys_emptyList() throws BackingStoreException {
 		doReturn(_basicPrefService).when(_map).get(anyString());
-
-		IEclipsePreferences mockedPreferences = mock(IEclipsePreferences.class);
-		doThrow(BackingStoreException.class).when(mockedPreferences).keys();
-		lenient().doReturn("aa").when(mockedPreferences).get(eq("a"), anyString());
-		lenient().doReturn("bb").when(mockedPreferences).get(eq("b"), anyString());
-
-		doReturn(mockedPreferences).when(_basicPrefService).getNode();
+		doReturn(new PreferenceKeyEnum[0]).when(_basicPrefService).getKeys();
 
 		Collection<PreferenceFeature> preferences = _logic.getPreferences("");
 

--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/part/InstanzViewLogicTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/part/InstanzViewLogicTest.java
@@ -3,18 +3,19 @@ package de.tonsias.basis.logic.test.part;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.core.services.events.IEventBroker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +25,9 @@ import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.Instanz;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.non.service.EventConstants;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
@@ -59,28 +63,42 @@ public class InstanzViewLogicTest {
 //		Job.getJobManager().join(_logic, new NullProgressMonitor());
 //	}
 
+	/**
+	 * Case 0 (apply) brackets the pending change jobs with an open and a close
+	 * operation event. Both are fired from scheduled {@link Job}s, so the test has
+	 * to wait for the job family before verifying.
+	 */
 	@Test
-	void testExecuteChanges_Case0() {
+	void testExecuteChanges_Case0() throws OperationCanceledException, InterruptedException {
 		var broker = mock(IEventBrokerBridge.class);
-		when(broker.post(anyString(), any())).thenReturn(true);
-		_logic.executeChanges(0, broker, null);
 
-		verify(broker, times(2)).post(anyString(), any());
+		_logic.executeChanges(0, broker, null);
+		Job.getJobManager().join(_logic, new NullProgressMonitor());
+
+		verify(broker).send(eq(EventConstants.OPEN_OPERATION), any());
+		verify(broker).send(eq(EventConstants.CLOSE_OPERATION), any());
 	}
 
+	/** Case 1 (cancel) discards the pending changes without notifying anyone. */
 	@Test
 	void testExecuteChanges_Case1() {
-		_logic.executeChanges(1, null, null);
+		var broker = mock(IEventBrokerBridge.class);
+
+		_logic.executeChanges(1, broker, null);
+
+		verifyNoInteractions(broker);
 	}
 
+	/** Case 2 (apply and reselect) re-selects the shown instanz synchronously. */
 	@Test
 	void testExecuteChanges_Case2() {
 		var broker = mock(IEventBrokerBridge.class);
-		when(broker.post(anyString(), any())).thenReturn(true);
 		var instanz = mock(Instanz.class);
+		when(instanz.getOwnKey()).thenReturn("key");
 
 		_logic.executeChanges(2, broker, instanz);
 
-		verify(broker, times(1)).post(anyString(), eq(instanz));
+		verify(broker).send(InstanzEventConstants.SELECTED,
+				Map.of(IEventBroker.DATA, new InstanzEvent("key", null)));
 	}
 }

--- a/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: de.tonsias.basis.osgi;bundle-version="1.0.0",
  de.tonsias.basis.data.access,
  de.tonsias.basis.model,
  org.eclipse.e4.core.services,
+ org.eclipse.e4.core.contexts,
  jakarta.inject.jakarta.inject-api,
  com.google.guava;bundle-version="33.1.0"
 Automatic-Module-Name: de.tonsias.basis.osgi.test

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
@@ -1,0 +1,65 @@
+package de.tonsias.basis.osgi.test;
+
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IContextFunction;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.util.ChangePropagationListener;
+
+/**
+ * Brings up the part of the runtime that the e4 application normally brings up
+ * for us.
+ * <p>
+ * {@link IEventBrokerBridge} and {@link IDeltaService} are not plain
+ * Declarative Services components: they are produced by
+ * {@link IContextFunction}s, which only run when an {@link IEclipseContext} is
+ * asked for their key. In the running product the workbench does the asking. In
+ * a headless test runtime nothing does, so the context functions never execute,
+ * the bridge is never registered in the service registry, and every
+ * {@code @Reference IEventBrokerBridge} stays unsatisfied - which in turn keeps
+ * {@code InstanzServiceImpl} and {@code SingleValueServiceImpl} from ever
+ * activating.
+ * </p>
+ * <p>
+ * Requesting the two keys once from the OSGi service context is enough: both
+ * context functions register their result as an OSGi service, after which
+ * Declarative Services can satisfy the dependent components and
+ * {@code OsgiUtil.getService(..)} resolves as it does in the product.
+ * </p>
+ */
+public final class E4ServiceContext {
+
+	private static boolean _primed;
+
+	private E4ServiceContext() {
+	}
+
+	/**
+	 * Idempotent; safe to call from every {@code @BeforeEach}.
+	 */
+	public static synchronized void prime() {
+		if (_primed) {
+			return;
+		}
+
+		BundleContext bundleContext = FrameworkUtil.getBundle(E4ServiceContext.class).getBundleContext();
+		IEclipseContext context = EclipseContextFactory.getServiceContext(bundleContext);
+
+		// order matters: the delta service depends on the bridge
+		context.get(IEventBrokerBridge.class.getName());
+		context.get(IDeltaService.class.getName());
+
+		// Application.e4xmi contributes this as an addon, which is what makes its
+		// @EventTopic methods subscribe. Without it nothing keeps both ends of a
+		// parent/child or instanz/value relation in sync, so e.g. createInstanz(..)
+		// never adds the new key to its parent's child list.
+		ContextInjectionFactory.make(ChangePropagationListener.class, context);
+
+		_primed = true;
+	}
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/InstanzServiceImplTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/InstanzServiceImplTest.java
@@ -31,6 +31,7 @@ import de.tonsias.basis.osgi.intf.IInstanzService;
 import de.tonsias.basis.osgi.intf.IKeyService;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
+import de.tonsias.basis.osgi.test.E4ServiceContext;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 
 public class InstanzServiceImplTest {
@@ -40,7 +41,11 @@ public class InstanzServiceImplTest {
 
 	@BeforeEach
 	void beforeEach() {
+		E4ServiceContext.prime();
 		_inse = OsgiUtil.getService(IInstanzService.class);
+		// the tests resolve the root by _parentKey; in the product ModelView does
+		// this at start-up, in a fresh test workspace nothing has created it yet
+		_inse.getRoot();
 	}
 
 	@AfterEach

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplTest.java
@@ -19,6 +19,7 @@ import de.tonsias.basis.osgi.intf.IDeltaService;
 import de.tonsias.basis.osgi.intf.IInstanzService;
 import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.test.E4ServiceContext;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 
 public class SingleValueServiceImplTest {
@@ -32,7 +33,9 @@ public class SingleValueServiceImplTest {
 
 	@BeforeEach
 	void beforeEach() {
+		E4ServiceContext.prime();
 		_ins = OsgiUtil.getService(IInstanzService.class);
+		_ins.getRoot();
 		_instanz = _ins.createInstanz(_originKey, Type.SEND);
 
 		_svs = OsgiUtil.getService(ISingleValueService.class);

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/util/OsgiUtilTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/util/OsgiUtilTest.java
@@ -1,0 +1,51 @@
+package de.tonsias.basis.osgi.test.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.osgi.intf.IKeyService;
+import de.tonsias.basis.osgi.test.E4ServiceContext;
+import de.tonsias.basis.osgi.util.OsgiUtil;
+
+/**
+ * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/22">#22</a>
+ */
+public class OsgiUtilTest {
+
+	@BeforeEach
+	void beforeEach() {
+		E4ServiceContext.prime();
+	}
+
+	@Test
+	void testGetService_registeredService_resolves() {
+		assertThat(OsgiUtil.getService(IKeyService.class), is(notNullValue()));
+	}
+
+	/**
+	 * {@code FrameworkUtil.getBundle(..)} returns null for a class that was not
+	 * loaded by a bundle class loader. That has to yield null rather than an NPE,
+	 * so callers can fall back on their own null handling.
+	 */
+	@Test
+	void testGetService_classNotFromABundle_returnsNull() {
+		assertThat(OsgiUtil.getService(String.class), is(nullValue()));
+	}
+
+	@Test
+	void testGetService_nullContext_returnsNull() {
+		assertThat(OsgiUtil.getService(IKeyService.class, null), is(nullValue()));
+	}
+
+	/** A well-formed context with nothing registered for the type is not an error. */
+	@Test
+	void testGetService_noServiceRegistered_returnsNull() {
+		var context = org.osgi.framework.FrameworkUtil.getBundle(OsgiUtilTest.class).getBundleContext();
+		assertThat(OsgiUtil.getService(java.util.RandomAccess.class, context), is(nullValue()));
+	}
+}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/OsgiUtil.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/OsgiUtil.java
@@ -2,20 +2,38 @@ package de.tonsias.basis.osgi.util;
 
 import java.util.function.Consumer;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 
 public class OsgiUtil {
+	/**
+	 * Look up a service without assuming a framework is present.
+	 *
+	 * @return the service, or <code>null</code> if the class was not loaded by a
+	 *         bundle class loader, the bundle is not started, or no service is
+	 *         registered
+	 */
 	public static <T> T getService(Class<T> clazz) {
-		BundleContext context = FrameworkUtil.getBundle(clazz).getBundleContext();
-		return getService(clazz, context);
+		Bundle bundle = FrameworkUtil.getBundle(clazz);
+		if (bundle == null) {
+			return null;
+		}
+		return getService(clazz, bundle.getBundleContext());
 	}
 
+	/**
+	 * @return the service, or <code>null</code> if the context is
+	 *         <code>null</code> or no service is registered
+	 */
 	public static <T> T getService(Class<T> clazz, BundleContext context) {
+		if (context == null) {
+			return null;
+		}
 		ServiceReference<T> serviceReference = context.getServiceReference(clazz);
-		if (context == null || serviceReference == null) {
+		if (serviceReference == null) {
 			return null;
 		}
 		return context.getService(serviceReference);


### PR DESCRIPTION
Fixes #22 and takes the suite from **18 failing of 44** to **48 passing of 48**. `./mvnw clean verify` is now green with no flags.

No production behaviour was changed to make a test pass. The only production change is the `OsgiUtil` fix in #22; everywhere else the *tests* were wrong and were corrected against the code.

## 1. `fix #22` — `OsgiUtil.getService` returns null instead of throwing

`getService(Class)` dereferenced `FrameworkUtil.getBundle(clazz)`, which is null whenever the class was not loaded by a bundle class loader, and the two-arg overload checked `context == null` on the line *after* it had already called `context.getServiceReference(clazz)`.

Callers already expect null — `PreferencesDialogLogic` initialises its fields with `getService(..)` and then guards `if (_keyPrefService == null || ...) return;`, a guard that could never run because the field initialiser threw first. `lazyLoading(..)` in the same class already returns early on a null context, so this just makes `getService` follow the existing convention.

Covered by a new `OsgiUtilTest`, whose `testGetService_classNotFromABundle_returnsNull` reproduces the old NPE.

## 2. The 14 service-test errors — the headless runtime was missing the product's wiring

`InstanzServiceImplTest` and `SingleValueServiceImplTest` failed every test on `OsgiUtil.getService(IInstanzService)` returning null. Three parts of the runtime are not plain DS components:

| Piece | Produced by | Triggered in the product by |
|---|---|---|
| `IEventBrokerBridge` | `EventBrokerContextFunction` (`IContextFunction`) | workbench asking the `IEclipseContext` for the key |
| `IDeltaService` | `DeltaServiceContextFunction` (`IContextFunction`) | same |
| `ChangePropagationListener` | e4 **addon** in `Application.e4xmi` | the e4 application creating addons |

Headless, nothing triggers any of them, so the bridge was never registered, `InstanzServiceImpl`'s mandatory `@Reference IEventBrokerBridge` stayed unsatisfied, and the component never activated.

New `E4ServiceContext.prime()` asks the OSGi service context for the two keys and creates the addon — enough for DS to satisfy the dependent components. The tests also now create the **root instanz**, which `ModelView` creates at start-up in the product but which does not exist in a fresh test workspace; without it `resolveKey("0")` returned empty and five tests threw `NoSuchElementException`.

This reproduces the product's own wiring rather than working around it, so these stay honest integration tests.

## 3. The 4 logic-test failures — stale expectations

**`InstanzViewLogicTest`**
- `executeChanges(..)` calls `broker.send(..)`, not `post(..)`; both surviving tests verified `post(..)` and could never pass.
- Case 0 fires its open/close operation events from scheduled `Job`s, so the test now joins the job family before verifying instead of asserting immediately.
- Case 2 sends `InstanzEventConstants.SELECTED` with a map holding an `InstanzEvent`; the test expected the instanz itself as the payload. It now stubs `getOwnKey()` and asserts the real topic and payload.
- Case 1 asserted nothing; it now verifies that cancelling notifies nobody.

**`PreferencesDialogLogicTest`**
- `testGetPreferences_validRequest` never stubbed `getNode()`, so the mock returned null and `getPreferences(..)` threw.
- `testGetPreferences_error_emptyList` stubbed `IEclipsePreferences.keys()` to throw `BackingStoreException`, but `getPreferences(..)` never calls `keys()` — and `getKeys()` was left unstubbed, returning null. The test asserted error handling that does not exist. Renamed to `testGetPreferences_noKeys_emptyList` and now asserts real behaviour: a preference declaring no keys yields no features.

## Manifest changes

- `osgi.test` needs `org.eclipse.e4.core.contexts` for `EclipseContextFactory`.
- `logic.test` needs `org.eclipse.e4.core.services` to reference `IEventBroker.DATA`, the key the production code publishes under.

## Docs

`CLAUDE.md` records the green baseline, documents `E4ServiceContext.prime()` and the root-instanz requirement for new service tests, and warns that `-pl <module> -am` does not work here — Tycho derives the reactor from the OSGi manifests, not Maven dependencies, so it misses required bundles and fails with "Missing requirement". Narrow with `-Dtest=` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
