### PR TITLE
fix #25 #26 #27 #28 #29 #30: persistence paths and the delete/parent bugs

### DIFF
--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/DeleteServiceImplTest.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/DeleteServiceImplTest.java
@@ -31,9 +31,23 @@ public class DeleteServiceImplTest {
 	}
 
 	/**
-	 * The service takes an absolute file path, not an object key - the callers in
-	 * {@code InstanzServiceImpl} / {@code SingleValueServiceImpl} hand it a bare
-	 * key, which is why deletes never reach a file.
+	 * A relative path is resolved against the workspace, the same way
+	 * {@code SaveService} writes it - that is what the services hand over.
+	 */
+	@Test
+	void testDeleteFile_relativePathIsResolvedAgainstTheWorkspace() throws IOException {
+		Path file = InstanceLocation.resolve("delete_test/relative.json");
+		Files.createDirectories(file.getParent());
+		Files.writeString(file, "{}");
+
+		assertThat(_deleteService.deleteFile("delete_test/relative.json"), is(true));
+
+		assertThat(Files.exists(file), is(false));
+	}
+
+	/**
+	 * The service takes the file path of an object, not its key - a bare key
+	 * denotes no file and deletes nothing.
 	 */
 	@Test
 	void testDeleteFile_unknownPathThrows() {

--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/InstanceLocation.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/InstanceLocation.java
@@ -1,9 +1,8 @@
 package de.tonsias.basis.data.access.test;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import org.eclipse.core.runtime.Platform;
+import de.tonsias.basis.data.access.osgi.impl.InstanceLocationUtil;
 
 /**
  * Resolves the workspace directory the same way {@code LoadServiceImpl} and
@@ -16,7 +15,6 @@ final class InstanceLocation {
 	}
 
 	static Path resolve(String relativePath) {
-		String dir = Platform.getInstanceLocation().getURL().getPath().substring(1);
-		return Paths.get(dir, relativePath);
+		return InstanceLocationUtil.resolve(relativePath);
 	}
 }

--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/InstanceLocationUtilTest.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/InstanceLocationUtilTest.java
@@ -1,0 +1,45 @@
+package de.tonsias.basis.data.access.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.Platform;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.data.access.osgi.impl.InstanceLocationUtil;
+
+public class InstanceLocationUtilTest {
+
+	/**
+	 * The instance location is a URL whose path carries a leading slash on Windows
+	 * ({@code /C:/ws}) but is the root itself everywhere else ({@code /home/u/ws}).
+	 * Cutting that first character turns the workspace into a relative path on
+	 * every non-Windows platform.
+	 */
+	@Test
+	void testGetDirectory_isTheInstanceLocationAsAFileSystemPath() {
+		Path dir = InstanceLocationUtil.getDirectory();
+
+		assertThat(dir.isAbsolute(), is(true));
+		assertThat(dir, is(new File(Platform.getInstanceLocation().getURL().getFile()).getAbsoluteFile().toPath()));
+	}
+
+	@Test
+	void testResolve_relativePathStaysInTheWorkspace() {
+		Path resolved = InstanceLocationUtil.resolve("instanz/key.json");
+
+		assertThat(resolved.isAbsolute(), is(true));
+		assertThat(resolved, is(InstanceLocationUtil.getDirectory().resolve(Paths.get("instanz", "key.json"))));
+	}
+
+	@Test
+	void testResolve_absolutePathIsTakenAsIs() {
+		Path absolute = InstanceLocationUtil.getDirectory().resolve("elsewhere.json").toAbsolutePath();
+
+		assertThat(InstanceLocationUtil.resolve(absolute.toString()), is(absolute));
+	}
+}

--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/SaveServiceImplTest.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/SaveServiceImplTest.java
@@ -85,6 +85,19 @@ public class SaveServiceImplTest {
 		assertThat(reloaded.getValue(), is("x"));
 	}
 
+	/** {@code LoadService} reads the files as UTF-8, so they have to be written as UTF-8. */
+	@Test
+	void testSafeAsGson_nonAsciiSurvivesTheRoundTrip() throws IOException {
+		SingleStringValue value = new SingleStringValue("save_umlaut");
+		value.tryToSetValue("Grüße, Straße");
+		_saveService.safeAsGson(value, value.getClass());
+
+		Path file = InstanceLocation.resolve("single_value/string/save_umlaut.json");
+		SingleStringValue reloaded = new Gson().fromJson(Files.readString(file), SingleStringValue.class);
+
+		assertThat(reloaded.getValue(), is("Grüße, Straße"));
+	}
+
 	@Test
 	void testSafeAsGsonCollection_writesAllElementsUnderTheFirstKey() throws IOException {
 		Path folder = InstanceLocation.resolve("instanz");

--- a/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/DeleteServiceImpl.java
+++ b/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/DeleteServiceImpl.java
@@ -2,7 +2,6 @@ package de.tonsias.basis.data.access.osgi.impl;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -11,9 +10,14 @@ import de.tonsias.basis.data.access.osgi.intf.DeleteService;
 @Component
 public class DeleteServiceImpl implements DeleteService {
 
+	/**
+	 * @param path file path of the object, relative to the workspace like the one
+	 *             {@code LoadService} and {@code SaveService} take - e.g.
+	 *             {@code instanz/<key>.json}, not the bare key
+	 */
 	@Override
 	public boolean deleteFile(String path) throws IOException {
-		Files.delete(Paths.get(path));
+		Files.delete(InstanceLocationUtil.resolve(path));
 		return true;
 	}
 

--- a/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/InstanceLocationUtil.java
+++ b/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/InstanceLocationUtil.java
@@ -1,0 +1,46 @@
+package de.tonsias.basis.data.access.osgi.impl;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.URIUtil;
+
+/**
+ * Resolves the workspace directory every persistence service writes to.
+ * <p>
+ * The instance location is a {@link URL}, and its path is not a file system
+ * path: on Windows it reads {@code /C:/ws/}, everywhere else {@code /home/u/ws}
+ * - so neither taking the path as is nor cutting its first character works on
+ * both. {@link URIUtil#toURI(URL)} is the platform's own conversion and handles
+ * the encoding (spaces, umlauts) on top.
+ */
+public final class InstanceLocationUtil {
+
+	private InstanceLocationUtil() {
+	}
+
+	/**
+	 * @return the workspace directory, without a trailing separator
+	 */
+	public static Path getDirectory() {
+		URL url = Platform.getInstanceLocation().getURL();
+		try {
+			return Paths.get(URIUtil.toURI(url));
+		} catch (URISyntaxException e) {
+			Platform.getLog(InstanceLocationUtil.class).error("Unusable instance location: " + url, e);
+			return Paths.get(url.getPath());
+		}
+	}
+
+	/**
+	 * @param relativePath path of an object relative to the workspace, an absolute
+	 *                     path is taken as is
+	 * @return the file the given path denotes
+	 */
+	public static Path resolve(String relativePath) {
+		return getDirectory().resolve(relativePath);
+	}
+}

--- a/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/LoadServiceImpl.java
+++ b/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/LoadServiceImpl.java
@@ -5,7 +5,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 
@@ -29,9 +28,8 @@ public class LoadServiceImpl implements LoadService {
 	private final Gson GSON = createGson();
 
 	private String getJson(String path) {
-		String dir = Platform.getInstanceLocation().getURL().getPath().substring(1);
 		String json = "";
-		Path pathToJson = Paths.get(dir + path + ".json");
+		Path pathToJson = InstanceLocationUtil.resolve(path + ".json");
 		try {
 			json = Files.readString(pathToJson);
 		} catch (IOException e) {

--- a/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/SaveServiceImpl.java
+++ b/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/impl/SaveServiceImpl.java
@@ -1,12 +1,10 @@
 package de.tonsias.basis.data.access.osgi.impl;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 
@@ -44,12 +42,11 @@ public class SaveServiceImpl implements SaveService {
 		};
 		String json = gson.toJson(list, typeToken);
 
-		String dir = Platform.getInstanceLocation().getURL().getPath().substring(1);
 		String pathName = list.iterator().next().getPath();
 		String fileName = list.iterator().next().getOwnKey();
-		Path path = Paths.get(dir + File.separator + pathName + fileName + ".json");
+		Path path = InstanceLocationUtil.resolve(pathName + fileName + ".json");
 		try {
-			Files.write(path, json.getBytes(), StandardOpenOption.CREATE);
+			write(path, json);
 		} catch (IOException e) {
 			Platform.getLog(getClass()).error("Unable to Safe: " + path.toString(), e);
 		}
@@ -62,16 +59,24 @@ public class SaveServiceImpl implements SaveService {
 		var type = TypeToken.getParameterized(objectType).getType();
 		String json = gson.toJson(object, type);
 
-		String dir = Platform.getInstanceLocation().getURL().getPath().substring(1);
 		String pathName = object.getPath();
 		String fileName = object.getOwnKey();
-		Path path = Paths.get(dir + File.separator + pathName + fileName + ".json");
+		Path path = InstanceLocationUtil.resolve(pathName + fileName + ".json");
 		try {
-			File file = new File(path.toString());
-			file.getParentFile().mkdirs();
-			Files.write(path, json.getBytes(), StandardOpenOption.CREATE);
+			Files.createDirectories(path.getParent());
+			write(path, json);
 		} catch (IOException e) {
 			Platform.getLog(getClass()).error("Unable to Safe: " + path.toString(), e);
 		}
+	}
+
+	/**
+	 * Replaces the whole file - without {@link StandardOpenOption#TRUNCATE_EXISTING}
+	 * a shorter document would leave the tail of the previous one behind and the
+	 * file would no longer parse.
+	 */
+	private void write(Path path, String json) throws IOException {
+		Files.writeString(path, json, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+				StandardOpenOption.TRUNCATE_EXISTING);
 	}
 }

--- a/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/intf/DeleteService.java
+++ b/de.tonsias.basis.data.access/src/de/tonsias/basis/data/access/osgi/intf/DeleteService.java
@@ -4,5 +4,10 @@ import java.io.IOException;
 
 public interface DeleteService {
 
+	/**
+	 * @param path file path of the object relative to the workspace, the same
+	 *             {@code <path><key>.json} {@link SaveService} writes to - a bare
+	 *             key denotes no file and deletes nothing
+	 */
 	boolean deleteFile(String path) throws IOException;
 }

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/InstanzServiceImplUnitTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/InstanzServiceImplUnitTest.java
@@ -258,6 +258,18 @@ public class InstanzServiceImplUnitTest {
 		assertThat(orphan.getParentKey(), is("parent"));
 	}
 
+	/** The listeners have to see that there was no old parent to detach from. */
+	@Test
+	void testChangeParent_firstParentIsReportedWithoutAnOldOne() {
+		givenOnDisk("orphan", new Instanz("orphan"));
+		givenOnDisk("parent", _parent);
+
+		_service.changeParent("orphan", "parent", Type.SEND);
+
+		verify(_broker).send(InstanzEventConstants.PARENT_CHANGE,
+				Map.of(IEventBroker.DATA, new ParentChange("orphan", "parent", null)));
+	}
+
 	@Test
 	void testChangeParent_unresolvableKeysAreRejected() {
 		givenOnDisk("child", null);

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplUnitTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplUnitTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -323,6 +324,39 @@ public class SingleValueServiceImplUnitTest {
 		assertThat(_service.deleteAll(Set.of()), is(true));
 
 		verifyNoInteractions(_deleteService);
+	}
+
+	/** Which folder a value lives in depends on its type. */
+	@Test
+	void testDeleteAll_cachedValueIsDeletedInItsOwnFolder() throws IOException {
+		when(_keyService.generateKey()).thenReturn("key");
+		_service.createNew(SingleIntegerValue.class, "owner", "paramName", 42, Type.SEND);
+
+		_service.deleteAll(Set.of("key"));
+
+		verify(_deleteService).deleteFile(SingleValueType.SINGLE_INTEGER.getPath() + "key.json");
+	}
+
+	/**
+	 * A value that is no longer cached no longer tells its type, so the folders
+	 * have to be tried one after the other.
+	 */
+	@Test
+	void testDeleteAll_uncachedValueIsLookedUpInEveryFolder() throws IOException {
+		when(_deleteService.deleteFile(STRING_PATH + "key.json")).thenThrow(new NoSuchFileException("nope"));
+
+		assertThat(_service.deleteAll(Set.of("key")), is(true));
+
+		verify(_deleteService).deleteFile(SingleValueType.SINGLE_INTEGER.getPath() + "key.json");
+	}
+
+	@Test
+	void testDeleteAll_valueInNoFolderAtAllFails() throws IOException {
+		when(_deleteService.deleteFile(anyString())).thenThrow(new NoSuchFileException("nope"));
+
+		CompletionException thrown = assertThrows(CompletionException.class, () -> _service.deleteAll(Set.of("key")));
+
+		assertThat(List.of(thrown.getSuppressed()), hasSize(1));
 	}
 
 	/** An {@link ISingleValue} that no {@code SingleValueType} knows about. */

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
@@ -36,6 +37,9 @@ import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ValueRenameE
 @Component
 public class InstanzServiceImpl implements IInstanzService {
 
+	/** every instanz is stored as {@code instanz/<key>.json} */
+	private static final String PATH = "instanz/";
+
 	@Reference
 	IKeyService _keyService;
 
@@ -56,7 +60,7 @@ public class InstanzServiceImpl implements IInstanzService {
 	@Override
 	public IInstanz getRoot() {
 		String rootID = String.valueOf(KeyServiceImpl.KEYCHARS[0]);
-		String path = "instanz/" + rootID;
+		String path = PATH + rootID;
 
 		if (_cache.containsKey(rootID)) {
 			return _cache.get(rootID);
@@ -86,7 +90,7 @@ public class InstanzServiceImpl implements IInstanzService {
 			return Optional.of(_cache.get(key));
 		}
 
-		String path = "instanz/" + key;
+		String path = PATH + key;
 		Instanz instanz = _loadService.loadFromGson(path, Instanz.class);
 
 		if (instanz != null) {
@@ -182,7 +186,8 @@ public class InstanzServiceImpl implements IInstanzService {
 		CompletionException ex = new CompletionException(null);
 		for (String key : instanzKeysToDelete) {
 			try {
-				_deleteService.deleteFile(key);
+				// the delete service works on files, the delta bookkeeping only knows keys
+				_deleteService.deleteFile(PATH + key + ".json");
 			} catch (IOException e) {
 				ex.addSuppressed(e);
 			}
@@ -243,11 +248,17 @@ public class InstanzServiceImpl implements IInstanzService {
 	public boolean changeParent(String childKey, String parentKey, IEventBrokerBridge.Type eventType) {
 		Optional<IInstanz> child = resolveKey(childKey);
 		Optional<IInstanz> parent = resolveKey(parentKey);
-		if (child.isEmpty() || parent.isEmpty() || child.get().getParentKey().equals(parentKey)) {
+		if (child.isEmpty() || parent.isEmpty()) {
 			return false;
 		}
 
-		var data = new ParentChange(childKey, parentKey, child.get().getParentKey());
+		// a freshly created instanz has no parent yet, that is a change as well
+		String oldParentKey = child.get().getParentKey();
+		if (Objects.equals(oldParentKey, parentKey)) {
+			return false;
+		}
+
+		var data = new ParentChange(childKey, parentKey, oldParentKey);
 		child.get().setParentKey(parentKey);
 		fireEvent(eventType, InstanzEventConstants.PARENT_CHANGE, data);
 		return true;

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -1,6 +1,7 @@
 package de.tonsias.basis.osgi.impl;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -167,7 +168,9 @@ public class SingleValueServiceImpl implements ISingleValueService {
 		var value = _cache.get(singleValueKeyToMark);
 		Optional<SingleValueType> optional = SingleValueType.getByClass(value.getClass());
 		optional.ifPresent(type -> {
-			Collection<String> connectedInstanzKeys = value.getConnectedInstanzKeys();
+			// a live view of the connections, so it has to be copied before they are cut -
+			// the event tells the owners to drop the value key and would carry nobody
+			Collection<String> connectedInstanzKeys = List.copyOf(value.getConnectedInstanzKeys());
 			value.removeConnection(connectedInstanzKeys);
 			var data = new SingleValueEventConstants.SingleValueDeleteEvent(type, singleValueKeyToMark, connectedInstanzKeys);
 			fireEvent(eventType, SingleValueEventConstants.DELETE, data);
@@ -179,9 +182,9 @@ public class SingleValueServiceImpl implements ISingleValueService {
 		CompletionException ex = new CompletionException(null);
 		for (String key : singlevalueKeysToDelete) {
 			try {
-				_deleteService.deleteFile(key);
+				deleteFile(key);
 			} catch (IOException e) {
-				ex.addSuppressed(ex);
+				ex.addSuppressed(e);
 			}
 		}
 
@@ -190,6 +193,34 @@ public class SingleValueServiceImpl implements ISingleValueService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * The delta bookkeeping only knows keys, the delete service works on files -
+	 * and which folder a value lives in depends on its type. A value that is no
+	 * longer cached no longer tells its type, so every folder is tried until one of
+	 * them holds the file.
+	 */
+	private void deleteFile(String key) throws IOException {
+		ISingleValue<?> cached = _cache.get(key);
+		if (cached != null) {
+			_deleteService.deleteFile(cached.getPath() + key + ".json");
+			return;
+		}
+
+		IOException notFound = null;
+		for (SingleValueType type : SingleValueType.values()) {
+			try {
+				_deleteService.deleteFile(type.getPath() + key + ".json");
+				return;
+			} catch (NoSuchFileException e) {
+				notFound = e;
+			}
+		}
+
+		if (notFound != null) {
+			throw notFound;
+		}
 	}
 
 	private void fireEvent(Type eventType, String eventName, Object data) {


### PR DESCRIPTION
Fixes the six bugs the test suite of #31 uncovered. Every test named in those issues passes now, the suite is at 242 tests, all green.

### Persistence (`de.tonsias.basis.data.access`)

- **#30** — the workspace directory was `getURL().getPath().substring(1)`. That leading slash only belongs to a Windows URL path (`/C:/…`); on Linux/macOS it is the root, so `/home/u/ws` became the relative `home/u/ws`. New `InstanceLocationUtil` converts the URL through `URIUtil.toURI(..)` once, and load, save and delete all go through it. `DeleteServiceImpl` resolved its argument against the process working directory before and now resolves it against the workspace like the other two.
- **#27** — `Files.write(.., CREATE)` does not truncate, so overwriting with a shorter document left the tail of the previous one behind and the file stopped parsing. Written with `TRUNCATE_EXISTING` now, and as UTF-8 — which is what `LoadService.readString` reads back.

### Services (`de.tonsias.basis.osgi`)

- **#26** — both `deleteAll` implementations passed the bare key to `DeleteService.deleteFile(..)`, which denotes no file, so nothing was ever deleted. Instanzes go to `instanz/<key>.json`. For single values the folder depends on the type: a cached value is deleted through its own `getPath()`, an uncached one is looked up in every value folder.
- **#25** — `deleteAll` called `ex.addSuppressed(ex)` on itself. Self-suppression is illegal, so the first `IOException` was replaced by an `IllegalArgumentException` and the real cause was lost.
- **#29** — `markSingleValueAsDelete` held the live view of the connections and cut them before building the event, so `SingleValueDeleteEvent` always carried an empty owner list and the owning instanzes kept a dangling value key. The keys are copied first.
- **#28** — `changeParent` compared `getParentKey().equals(parentKey)`, so giving a freshly created instanz its first parent threw an NPE instead of firing `PARENT_CHANGE` with a `null` old parent.

### Tests

Beyond the ones that came with the issues: `InstanceLocationUtilTest`, delete through a relative path, a non-ASCII save round trip, the two single-value delete folder paths and the missing-file case, and the `PARENT_CHANGE` payload of a first parent.

`./mvnw clean verify` — 242 tests, 0 failures, product builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
