### PR TITLE
feat #34: Systemtests für die gesamte Event-Kette

### DIFF
--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
@@ -36,6 +36,13 @@ public final class E4ServiceContext {
 
 	private static boolean _primed;
 
+	/**
+	 * e4 keeps only a weak reference to an injected object, so a listener nobody
+	 * holds on to can be collected in the middle of a run - and the propagation it
+	 * does would then silently stop.
+	 */
+	private static ChangePropagationListener _listener;
+
 	private E4ServiceContext() {
 	}
 
@@ -58,7 +65,7 @@ public final class E4ServiceContext {
 		// @EventTopic methods subscribe. Without it nothing keeps both ends of a
 		// parent/child or instanz/value relation in sync, so e.g. createInstanz(..)
 		// never adds the new key to its parent's child list.
-		ContextInjectionFactory.make(ChangePropagationListener.class, context);
+		_listener = ContextInjectionFactory.make(ChangePropagationListener.class, context);
 
 		_primed = true;
 	}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
@@ -1,0 +1,329 @@
+package de.tonsias.basis.osgi.test.system;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.URIUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.service.event.Event;
+
+import de.tonsias.basis.data.access.osgi.intf.LoadService;
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.Instanz;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
+import de.tonsias.basis.osgi.intf.non.service.EventConstants;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
+import de.tonsias.basis.osgi.test.E4ServiceContext;
+import de.tonsias.basis.osgi.util.OsgiUtil;
+
+/**
+ * The other half of the event system: what the chains of
+ * {@link EventChainSystemTest} end up doing to the files.
+ * <p>
+ * Everything here goes through the real {@code DeltaServiceImpl}, which
+ * subscribes to the same two wildcard topics the services fire on, folds its
+ * event log into four key sets and hands them to the services. So a chain that
+ * loses an event loses a file, and one that fires an event too many deletes a
+ * file that is still referenced. The assertions therefore never look at the
+ * caches: every object is read back from disk with the {@link LoadService}.
+ * </p>
+ */
+public class DeltaPersistenceSystemTest {
+
+	private static final String ROOT = "0";
+
+	private static final String INSTANZ_PATH = "instanz/";
+
+	IInstanzService _inse;
+
+	ISingleValueService _svs;
+
+	IDeltaService _delta;
+
+	IEventBrokerBridge _broker;
+
+	LoadService _load;
+
+	@BeforeEach
+	void beforeEach() {
+		E4ServiceContext.prime();
+		_inse = OsgiUtil.getService(IInstanzService.class);
+		_svs = OsgiUtil.getService(ISingleValueService.class);
+		_delta = OsgiUtil.getService(IDeltaService.class);
+		_broker = OsgiUtil.getService(IEventBrokerBridge.class);
+		_load = OsgiUtil.getService(LoadService.class);
+		// in the product ModelView creates the root at start-up
+		_inse.getRoot();
+
+		flush();
+	}
+
+	@Test
+	void testCreateInstanz_savesTheNewInstanzAndItsParent() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		// there is deliberately no "the file does not exist yet" check here: keys are
+		// base 62 and become file names as they are, so on a case insensitive file
+		// system "a" and "A" are one and the same file (see issue #35)
+
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(instanzFile(child.getOwnKey())), is(true));
+		assertThat(reloadInstanz(child.getOwnKey()).getParentKey(), is(ROOT));
+		// the parent is only touched by the propagated child list change - without it
+		// the tree would be broken on the next start
+		assertThat(reloadInstanz(ROOT).getChildren(), hasItem(child.getOwnKey()));
+	}
+
+	@Test
+	void testSaveAllEvent_triggersTheSave() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+
+		_broker.send(EventConstants.SAVE_ALL, "save");
+
+		assertThat(Files.exists(instanzFile(child.getOwnKey())), is(true));
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	/**
+	 * Everything the services put on the bus has to reach the log, because the log
+	 * is the only record of what still needs saving.
+	 */
+	@Test
+	void testDeltaLog_collectsEveryEventOfTheChain() {
+		int before = _delta.getDeltas().size();
+
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content", Type.SEND);
+
+		assertThat(deltaTopicsSince(before),
+				containsInAnyOrder(InstanzEventConstants.NEW, InstanzEventConstants.CHILD_LIST_CHANGE,
+						SingleValueEventConstants.NEW, InstanzEventConstants.VALUE_LIST_CHANGE));
+
+		_delta.saveDeltas();
+
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	@Test
+	void testCreateSingleValue_savesTheValueAndTheOwnerThatReferencesIt() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(stringValueFile(value.getOwnKey())), is(true));
+		SingleStringValue reloaded = reloadStringValue(value.getOwnKey());
+		assertThat(reloaded.getValue(), is("content"));
+		assertThat(reloaded.getConnectedInstanzKeys(), contains(owner.getOwnKey()));
+
+		assertThat(reloadInstanz(owner.getOwnKey()).getSingleValues(SingleValueType.SINGLE_STRING)
+				.get(value.getOwnKey()), is("parameter"));
+	}
+
+	@Test
+	void testChangeValue_isPersisted() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "old",
+				Type.SEND);
+		_delta.saveDeltas();
+
+		_svs.changeValue(value.getOwnKey(), "new", Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(reloadStringValue(value.getOwnKey()).getValue(), is("new"));
+	}
+
+	@Test
+	void testAddToParent_persistsTheLinkOnBothSides() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz secondOwner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_delta.saveDeltas();
+
+		_svs.addToParent(SingleValueType.SINGLE_STRING, value.getOwnKey(), secondOwner.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(reloadStringValue(value.getOwnKey()).getConnectedInstanzKeys(),
+				containsInAnyOrder(owner.getOwnKey(), secondOwner.getOwnKey()));
+		assertThat(reloadInstanz(secondOwner.getOwnKey()).getSingleValues(SingleValueType.SINGLE_STRING)
+				.containsKey(value.getOwnKey()), is(true));
+	}
+
+	@Test
+	void testChangeSingleValueName_isPersistedOnTheOwner() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "oldName", "content",
+				Type.SEND);
+		_delta.saveDeltas();
+
+		_inse.changeSingleValueName(owner.getOwnKey(), SingleValueType.SINGLE_STRING, value.getOwnKey(), "newName",
+				Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(reloadInstanz(owner.getOwnKey()).getSingleValues(SingleValueType.SINGLE_STRING)
+				.get(value.getOwnKey()), is("newName"));
+	}
+
+	/**
+	 * The delete event carries the owners with it, and the value list changes it
+	 * causes are what puts those owners into the save set - so the file goes and
+	 * no owner is left pointing at it.
+	 */
+	@Test
+	void testMarkSingleValueAsDelete_deletesTheFileAndRewritesEveryOwner() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz secondOwner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_svs.addToParent(SingleValueType.SINGLE_STRING, value.getOwnKey(), secondOwner.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+		assertThat(Files.exists(stringValueFile(value.getOwnKey())), is(true));
+
+		_svs.markSingleValueAsDelete(value.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(stringValueFile(value.getOwnKey())), is(false));
+		assertThat(reloadInstanz(owner.getOwnKey()).getSingleValues(SingleValueType.SINGLE_STRING)
+				.containsKey(value.getOwnKey()), is(false));
+		assertThat(reloadInstanz(secondOwner.getOwnKey()).getSingleValues(SingleValueType.SINGLE_STRING)
+				.containsKey(value.getOwnKey()), is(false));
+	}
+
+	@Test
+	void testRemoveChild_deletesTheWholeSubtreeFromDisk() {
+		IInstanz branch = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz leaf = _inse.createInstanz(branch.getOwnKey(), Type.SEND);
+		IInstanz deepLeaf = _inse.createInstanz(leaf.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+		assertThat(Files.exists(instanzFile(deepLeaf.getOwnKey())), is(true));
+
+		_inse.removeChild(ROOT, branch.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(instanzFile(branch.getOwnKey())), is(false));
+		assertThat(Files.exists(instanzFile(leaf.getOwnKey())), is(false));
+		assertThat(Files.exists(instanzFile(deepLeaf.getOwnKey())), is(false));
+		assertThat(reloadInstanz(ROOT).getChildren(), not(hasItem(branch.getOwnKey())));
+	}
+
+	/**
+	 * A move runs through the same child list change as a delete does. If the
+	 * listener ever stopped telling the two apart, this is where it would show:
+	 * the moved instanz would be deleted instead of re-parented.
+	 */
+	@Test
+	void testPutChild_move_rewritesThreeFilesAndDeletesNone() {
+		IInstanz oldParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz newParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz moved = _inse.createInstanz(oldParent.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		_inse.putChild(newParent.getOwnKey(), moved.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(instanzFile(moved.getOwnKey())), is(true));
+		assertThat(reloadInstanz(moved.getOwnKey()).getParentKey(), is(newParent.getOwnKey()));
+		assertThat(reloadInstanz(newParent.getOwnKey()).getChildren(), contains(moved.getOwnKey()));
+		assertThat(reloadInstanz(oldParent.getOwnKey()).getChildren(), not(hasItem(moved.getOwnKey())));
+	}
+
+	@Test
+	void testSaveDeltas_withoutAnyChange_writesNothingNew() {
+		IInstanz untouched = _inse.createInstanz(ROOT, Type.SEND);
+		_delta.saveDeltas();
+
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(instanzFile(untouched.getOwnKey())), is(true));
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	/**
+	 * Create and delete within one bracket: the log holds both the new and the
+	 * delete event for the same key, and the delete has to win - otherwise a file
+	 * nobody references anymore is left behind.
+	 */
+	@Test
+	void testSaveDeltas_createAndDeleteBeforeTheSave_leavesNoFile() {
+		IInstanz shortLived = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.removeChild(ROOT, shortLived.getOwnKey(), Type.SEND);
+
+		_delta.saveDeltas();
+
+		assertThat(Files.exists(instanzFile(shortLived.getOwnKey())), is(false));
+		assertThat(reloadInstanz(ROOT).getChildren(), not(hasItem(shortLived.getOwnKey())));
+	}
+
+	/**
+	 * events the delta service has taken since the given position in its log
+	 */
+	private List<String> deltaTopicsSince(int index) {
+		return _delta.getDeltas().stream().skip(index).map(Event::getTopic).toList();
+	}
+
+	private void flush() {
+		try {
+			_delta.saveDeltas();
+		} catch (CompletionException e) {
+			// an earlier test may have left a delete for a file that was never written
+		}
+	}
+
+	private Instanz reloadInstanz(String key) {
+		Instanz loaded = _load.loadFromGson(INSTANZ_PATH + key, Instanz.class);
+		assertThat("no file for instanz " + key, loaded, is(not(nullValue())));
+		return loaded;
+	}
+
+	private SingleStringValue reloadStringValue(String key) {
+		SingleStringValue loaded = _load.loadFromGson(SingleValueType.SINGLE_STRING.getPath() + key,
+				SingleStringValue.class);
+		assertThat("no file for single value " + key, loaded, is(not(nullValue())));
+		return loaded;
+	}
+
+	private static Path instanzFile(String key) {
+		return workspace().resolve(INSTANZ_PATH + key + ".json");
+	}
+
+	private static Path stringValueFile(String key) {
+		return workspace().resolve(SingleValueType.SINGLE_STRING.getPath() + key + ".json");
+	}
+
+	/**
+	 * the directory the persistence services write to, resolved the same way
+	 * {@code InstanceLocationUtil} does
+	 */
+	private static Path workspace() {
+		URL url = Platform.getInstanceLocation().getURL();
+		try {
+			return Paths.get(URIUtil.toURI(url));
+		} catch (URISyntaxException e) {
+			throw new AssertionError("unusable instance location: " + url, e);
+		}
+	}
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
@@ -1,0 +1,576 @@
+package de.tonsias.basis.osgi.test.system;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleIntegerValue;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ChangeType;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedChildChangeEvent;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedValueChangeEvent;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ParentChange;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ValueRenameEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.LinkedInstanzChangeEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.SingleValueDeleteEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.SingleValueNewEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.ValueChangeEvent;
+import de.tonsias.basis.osgi.test.E4ServiceContext;
+import de.tonsias.basis.osgi.util.ChangePropagationListener;
+import de.tonsias.basis.osgi.util.OsgiUtil;
+
+/**
+ * End-to-end tests of the event bus: real {@code InstanzServiceImpl}, real
+ * {@code SingleValueServiceImpl}, the real broker and the real
+ * {@link ChangePropagationListener} in between - nothing is mocked.
+ * <p>
+ * Every mutating service call is only the first link of a chain: the service
+ * fires an event, the listener turns that event into calls on the <em>other</em>
+ * side of the relation, and those fire events again. Each test therefore checks
+ * three things:
+ * </p>
+ * <ol>
+ * <li>which events the chain produced - no more (a missing loop guard) and no
+ * fewer (propagation stopped early) than expected,</li>
+ * <li>what the payloads carry, because the delta service derives the keys it
+ * saves and deletes from exactly those payloads,</li>
+ * <li>that both ends of the relation agree afterwards.</li>
+ * </ol>
+ * The effect of those events on the files is covered by
+ * {@link DeltaPersistenceSystemTest}.
+ */
+public class EventChainSystemTest {
+
+	private static final String ROOT = "0";
+
+	IInstanzService _inse;
+
+	ISingleValueService _svs;
+
+	EventRecorder _recorder;
+
+	@BeforeEach
+	void beforeEach() {
+		E4ServiceContext.prime();
+		_inse = OsgiUtil.getService(IInstanzService.class);
+		_svs = OsgiUtil.getService(ISingleValueService.class);
+		// in the product ModelView creates the root at start-up
+		_inse.getRoot();
+
+		_recorder = EventRecorder.subscribeToAllDeltas(OsgiUtil.getService(IEventBrokerBridge.class));
+	}
+
+	@AfterEach
+	void afterEach() {
+		_recorder.unsubscribe();
+		try {
+			// keeps the shared delta log from carrying this test's events into the next
+			OsgiUtil.getService(IDeltaService.class).saveDeltas();
+		} catch (CompletionException e) {
+		}
+	}
+
+	/**
+	 * ------------- parent / child chains -------------
+	 */
+
+	@Test
+	void testCreateInstanz_newAndChildListChange_linkBothSides() {
+		_recorder.clear();
+
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.NEW, InstanzEventConstants.CHILD_LIST_CHANGE));
+
+		InstanzEvent created = _recorder.onlyDataOf(InstanzEventConstants.NEW, InstanzEvent.class);
+		assertThat(created._key(), is(child.getOwnKey()));
+		assertThat(created._parentKey(), is(ROOT));
+
+		LinkedChildChangeEvent childList = _recorder.onlyDataOf(InstanzEventConstants.CHILD_LIST_CHANGE,
+				LinkedChildChangeEvent.class);
+		assertThat(childList._key(), is(ROOT));
+		assertThat(childList._changeType(), is(ChangeType.ADD));
+		assertThat(childList._instanzKeys(), contains(child.getOwnKey()));
+
+		assertThat(child.getParentKey(), is(ROOT));
+		assertThat(_inse.resolveKey(ROOT).get().getChildren(), hasItem(child.getOwnKey()));
+	}
+
+	/**
+	 * The child list change makes the listener call back into
+	 * {@code changeParent}, which must recognise that the parent it is asked for
+	 * is already set and stay silent - otherwise the two handlers keep answering
+	 * each other.
+	 */
+	@Test
+	void testCreateInstanz_parentIsAlreadySet_soNoParentChangeIsFired() {
+		_recorder.clear();
+
+		_inse.createInstanz(ROOT, Type.SEND);
+
+		assertThat(_recorder.topics(), not(hasItem(InstanzEventConstants.PARENT_CHANGE)));
+	}
+
+	@Test
+	void testCreateInstanz_belowAnotherNewInstanz_propagatesOnlyToItsOwnParent() {
+		IInstanz parent = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		IInstanz child = _inse.createInstanz(parent.getOwnKey(), Type.SEND);
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.NEW, InstanzEventConstants.CHILD_LIST_CHANGE));
+		assertThat(_recorder.onlyDataOf(InstanzEventConstants.CHILD_LIST_CHANGE, LinkedChildChangeEvent.class)._key(),
+				is(parent.getOwnKey()));
+
+		assertThat(parent.getChildren(), contains(child.getOwnKey()));
+		assertThat(_inse.resolveKey(ROOT).get().getChildren(), not(hasItem(child.getOwnKey())));
+	}
+
+	@Test
+	void testCreateInstanz_invalidParentKey_firesNothing() {
+		_recorder.clear();
+
+		assertThat(_inse.createInstanz(null, Type.SEND), is(nullValue()));
+		assertThat(_inse.createInstanz("", Type.SEND), is(nullValue()));
+		assertThat(_inse.createInstanz("   ", Type.SEND), is(nullValue()));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	/**
+	 * Moving a child is the chain with the most links: add on the new parent ->
+	 * parent change on the child -> remove on the old parent. The remove must
+	 * <em>not</em> reach the delete branch of the listener, or every move would
+	 * throw away the moved subtree.
+	 */
+	@Test
+	void testPutChild_moveToAnotherParent_reparentsWithoutDeleting() {
+		IInstanz oldParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz newParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz moved = _inse.createInstanz(oldParent.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.putChild(newParent.getOwnKey(), moved.getOwnKey(), Type.SEND), is(true));
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.CHILD_LIST_CHANGE, InstanzEventConstants.PARENT_CHANGE,
+						InstanzEventConstants.CHILD_LIST_CHANGE));
+
+		ParentChange parentChange = _recorder.onlyDataOf(InstanzEventConstants.PARENT_CHANGE, ParentChange.class);
+		assertThat(parentChange._key(), is(moved.getOwnKey()));
+		assertThat(parentChange._newParentKey(), is(newParent.getOwnKey()));
+		assertThat(parentChange._oldParentKey(), is(oldParent.getOwnKey()));
+
+		assertThat(childListChangeOf(newParent)._changeType(), is(ChangeType.ADD));
+		assertThat(childListChangeOf(newParent)._instanzKeys(), contains(moved.getOwnKey()));
+		assertThat(childListChangeOf(oldParent)._changeType(), is(ChangeType.REMOVE));
+		assertThat(childListChangeOf(oldParent)._instanzKeys(), contains(moved.getOwnKey()));
+
+		assertThat(moved.getParentKey(), is(newParent.getOwnKey()));
+		assertThat(newParent.getChildren(), contains(moved.getOwnKey()));
+		assertThat(oldParent.getChildren(), not(hasItem(moved.getOwnKey())));
+	}
+
+	@Test
+	void testChangeParent_producesTheSameLinkageAsPutChild() {
+		IInstanz oldParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz newParent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz moved = _inse.createInstanz(oldParent.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.changeParent(moved.getOwnKey(), newParent.getOwnKey(), Type.SEND), is(true));
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.PARENT_CHANGE, InstanzEventConstants.CHILD_LIST_CHANGE,
+						InstanzEventConstants.CHILD_LIST_CHANGE));
+
+		assertThat(moved.getParentKey(), is(newParent.getOwnKey()));
+		assertThat(newParent.getChildren(), contains(moved.getOwnKey()));
+		assertThat(oldParent.getChildren(), not(hasItem(moved.getOwnKey())));
+	}
+
+	@Test
+	void testChangeParent_toTheParentItAlreadyHas_firesNothing() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.changeParent(child.getOwnKey(), ROOT, Type.SEND), is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	@Test
+	void testPutChild_childItAlreadyHas_firesNothing() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.putChild(ROOT, child.getOwnKey(), Type.SEND), is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	/**
+	 * Removing a child is a delete: the child list change reaches the delete
+	 * branch of the listener, which detaches the child and marks it - and from
+	 * there every descendant - for deletion.
+	 */
+	@Test
+	void testRemoveChild_marksTheWholeSubtreeAsDeleted() {
+		IInstanz branch = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz leaf = _inse.createInstanz(branch.getOwnKey(), Type.SEND);
+		IInstanz deepLeaf = _inse.createInstanz(leaf.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeChild(ROOT, branch.getOwnKey(), Type.SEND), is(true));
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.CHILD_LIST_CHANGE, InstanzEventConstants.DELETE,
+						InstanzEventConstants.DELETE, InstanzEventConstants.DELETE));
+
+		assertThat(_recorder.dataOf(InstanzEventConstants.DELETE, InstanzEvent.class).stream().map(InstanzEvent::_key)
+				.toList(), containsInAnyOrder(branch.getOwnKey(), leaf.getOwnKey(), deepLeaf.getOwnKey()));
+
+		LinkedChildChangeEvent childList = _recorder.onlyDataOf(InstanzEventConstants.CHILD_LIST_CHANGE,
+				LinkedChildChangeEvent.class);
+		assertThat(childList._key(), is(ROOT));
+		assertThat(childList._changeType(), is(ChangeType.REMOVE));
+
+		// only the removed instanz loses its parent, the subtree below it stays
+		// intact - that is what makes the delete undoable in one piece
+		assertThat(branch.getParentKey(), is(nullValue()));
+		assertThat(_inse.resolveKey(ROOT).get().getChildren(), not(hasItem(branch.getOwnKey())));
+		assertThat(branch.getChildren(), contains(leaf.getOwnKey()));
+		assertThat(leaf.getParentKey(), is(branch.getOwnKey()));
+	}
+
+	@Test
+	void testRemoveSubtreeInstanz_calledDirectly_producesTheSameChain() {
+		IInstanz branch = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz leaf = _inse.createInstanz(branch.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeSubtreeInstanz(branch.getOwnKey(), Type.SEND), is(true));
+
+		assertThat(_recorder.topics(), containsInAnyOrder(InstanzEventConstants.CHILD_LIST_CHANGE,
+				InstanzEventConstants.DELETE, InstanzEventConstants.DELETE));
+		assertThat(_recorder.dataOf(InstanzEventConstants.DELETE, InstanzEvent.class).stream().map(InstanzEvent::_key)
+				.toList(), containsInAnyOrder(branch.getOwnKey(), leaf.getOwnKey()));
+	}
+
+	/**
+	 * The detached instanz is what the listener calls back with after the remove,
+	 * so the second run has to be silent - it is the guard that ends the chain.
+	 */
+	@Test
+	void testRemoveSubtreeInstanz_alreadyDetached_firesNothing() {
+		IInstanz branch = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.removeSubtreeInstanz(branch.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeSubtreeInstanz(branch.getOwnKey(), Type.SEND), is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	@Test
+	void testRemoveChild_keyIsNotAChild_firesNothing() {
+		IInstanz stranger = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz other = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeChild(stranger.getOwnKey(), other.getOwnKey(), Type.SEND), is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+		assertThat(other.getParentKey(), is(ROOT));
+	}
+
+	/**
+	 * ------------- instanz / single value chains -------------
+	 */
+
+	@Test
+	void testCreateSingleValue_linksValueAndOwnerBothWays() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(SingleValueEventConstants.NEW, InstanzEventConstants.VALUE_LIST_CHANGE));
+
+		SingleValueNewEvent created = _recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class);
+		assertThat(created._key(), is(value.getOwnKey()));
+		assertThat(created._type(), is(SingleValueType.SINGLE_STRING));
+		assertThat(created._name(), is("parameter"));
+		assertThat(created._ownerKeys(), contains(owner.getOwnKey()));
+
+		LinkedValueChangeEvent valueList = _recorder.onlyDataOf(InstanzEventConstants.VALUE_LIST_CHANGE,
+				LinkedValueChangeEvent.class);
+		assertThat(valueList._key(), is(owner.getOwnKey()));
+		assertThat(valueList._singleValuetype(), is(SingleValueType.SINGLE_STRING));
+		assertThat(valueList._changeType(), is(ChangeType.ADD));
+		assertThat(valueList._valueKeys(), contains(value.getOwnKey()));
+
+		assertThat(value.getConnectedInstanzKeys(), contains(owner.getOwnKey()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).get(value.getOwnKey()), is("parameter"));
+	}
+
+	/**
+	 * The value already knows its first owner when the event goes out, so the
+	 * listener's call back into {@code addToParent} must not answer with another
+	 * event.
+	 */
+	@Test
+	void testCreateSingleValue_ownerIsAlreadyConnected_soNoInstanzListChangeIsFired() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		_svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content", Type.SEND);
+
+		assertThat(_recorder.topics(), not(hasItem(SingleValueEventConstants.INSTANZ_LIST_CHANGE)));
+	}
+
+	@Test
+	void testAddToParent_secondOwner_linksBothWaysAndNamesTheValueAfterItsKey() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz secondOwner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.addToParent(SingleValueType.SINGLE_STRING, value.getOwnKey(), secondOwner.getOwnKey(),
+				Type.SEND), is(true));
+
+		assertThat(_recorder.topics(), containsInAnyOrder(SingleValueEventConstants.INSTANZ_LIST_CHANGE,
+				InstanzEventConstants.VALUE_LIST_CHANGE));
+
+		LinkedInstanzChangeEvent instanzList = _recorder.onlyDataOf(SingleValueEventConstants.INSTANZ_LIST_CHANGE,
+				LinkedInstanzChangeEvent.class);
+		assertThat(instanzList._key(), is(value.getOwnKey()));
+		assertThat(instanzList._changeType(), is(LinkedInstanzChangeEvent.ChangeType.ADD));
+		assertThat(instanzList._instanzKeys(), contains(secondOwner.getOwnKey()));
+
+		assertThat(value.getConnectedInstanzKeys(),
+				containsInAnyOrder(owner.getOwnKey(), secondOwner.getOwnKey()));
+		// the chain carries no name for the new owner, so the key stands in for it
+		assertThat(secondOwner.getSingleValues(SingleValueType.SINGLE_STRING).get(value.getOwnKey()),
+				is(value.getOwnKey()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).get(value.getOwnKey()), is("parameter"));
+	}
+
+	@Test
+	void testAddToParent_ownerIsAlreadyConnected_firesNothing() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.addToParent(SingleValueType.SINGLE_STRING, value.getOwnKey(), owner.getOwnKey(), Type.SEND),
+				is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	@Test
+	void testChangeValue_firesOnlyOnTheValueItself() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "old",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.changeValue(value.getOwnKey(), "new", Type.SEND), is(true));
+
+		assertThat(_recorder.topics(), contains(SingleValueEventConstants.VALUE_CHANGE));
+
+		ValueChangeEvent changed = _recorder.onlyDataOf(SingleValueEventConstants.VALUE_CHANGE, ValueChangeEvent.class);
+		assertThat(changed._key(), is(value.getOwnKey()));
+		assertThat(changed._type(), is(SingleValueType.SINGLE_STRING));
+		assertThat(changed._oldValue(), is("old"));
+		assertThat(changed._newValue(), is("new"));
+
+		assertThat(value.getValue(), is("new"));
+	}
+
+	@Test
+	void testChangeValue_toTheValueItAlreadyHas_firesNothing() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.changeValue(value.getOwnKey(), "content", Type.SEND), is(false));
+
+		assertThat(_recorder.events(), is(empty()));
+	}
+
+	/**
+	 * The name of an attribute belongs to the owning instanz, not to the value, so
+	 * the rename must stay on the instanz side of the bus.
+	 */
+	@Test
+	void testChangeSingleValueName_staysOnTheOwner() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "oldName", "content",
+				Type.SEND);
+		_recorder.clear();
+
+		_inse.changeSingleValueName(owner.getOwnKey(), SingleValueType.SINGLE_STRING, value.getOwnKey(), "newName",
+				Type.SEND);
+
+		assertThat(_recorder.topics(), contains(InstanzEventConstants.NAME_CHANGE));
+
+		ValueRenameEvent renamed = _recorder.onlyDataOf(InstanzEventConstants.NAME_CHANGE, ValueRenameEvent.class);
+		assertThat(renamed._key(), is(owner.getOwnKey()));
+		assertThat(renamed._attrKey(), is(value.getOwnKey()));
+		assertThat(renamed._oldName(), is("oldName"));
+		assertThat(renamed._newName(), is("newName"));
+
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).get(value.getOwnKey()), is("newName"));
+		assertThat(value.getConnectedInstanzKeys(), contains(owner.getOwnKey()));
+	}
+
+	/**
+	 * Deleting a value has to reach every instanz that references it, otherwise an
+	 * owner keeps a key whose file is gone.
+	 */
+	@Test
+	void testMarkSingleValueAsDelete_dropsTheKeyFromEveryOwner() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz secondOwner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_svs.addToParent(SingleValueType.SINGLE_STRING, value.getOwnKey(), secondOwner.getOwnKey(), Type.SEND);
+		_recorder.clear();
+
+		_svs.markSingleValueAsDelete(value.getOwnKey(), Type.SEND);
+
+		assertThat(_recorder.topics(), containsInAnyOrder(SingleValueEventConstants.DELETE,
+				InstanzEventConstants.VALUE_LIST_CHANGE, InstanzEventConstants.VALUE_LIST_CHANGE));
+
+		SingleValueDeleteEvent deleted = _recorder.onlyDataOf(SingleValueEventConstants.DELETE,
+				SingleValueDeleteEvent.class);
+		assertThat(deleted._key(), is(value.getOwnKey()));
+		assertThat(deleted._type(), is(SingleValueType.SINGLE_STRING));
+		// the connections are cut before the event goes out, so it has to carry its
+		// own copy - the owners could not be found afterwards
+		assertThat(deleted._ownerKeys(), containsInAnyOrder(owner.getOwnKey(), secondOwner.getOwnKey()));
+
+		assertThat(_recorder.dataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class).stream()
+				.map(LinkedValueChangeEvent::_key).toList(),
+				containsInAnyOrder(owner.getOwnKey(), secondOwner.getOwnKey()));
+		_recorder.dataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class)
+				.forEach(data -> assertThat(data._changeType(), is(ChangeType.REMOVE)));
+
+		assertThat(value.getConnectedInstanzKeys(), is(empty()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).containsKey(value.getOwnKey()), is(false));
+		assertThat(secondOwner.getSingleValues(SingleValueType.SINGLE_STRING).containsKey(value.getOwnKey()),
+				is(false));
+	}
+
+	@Test
+	void testRemoveValue_producesTheSameChainAsMarkAsDelete() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.removeValue(value, Type.SEND), is(true));
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(SingleValueEventConstants.DELETE, InstanzEventConstants.VALUE_LIST_CHANGE));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).containsKey(value.getOwnKey()), is(false));
+	}
+
+	/**
+	 * An integer value walks the same chain as a string one, but through the other
+	 * half of {@code SingleValueType} - the type travels in the payload and picks
+	 * the map the owner stores the key in.
+	 */
+	@Test
+	void testCreateSingleValue_integer_usesItsOwnTypeThroughoutTheChain() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		SingleIntegerValue value = _svs.createNew(SingleIntegerValue.class, owner.getOwnKey(), "number", 42, Type.SEND);
+
+		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
+				is(SingleValueType.SINGLE_INTEGER));
+		assertThat(_recorder.onlyDataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class)
+				._singleValuetype(), is(SingleValueType.SINGLE_INTEGER));
+
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_INTEGER).get(value.getOwnKey()), is("number"));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).keySet(), is(empty()));
+	}
+
+	/**
+	 * ------------- asynchronous delivery -------------
+	 */
+
+	/**
+	 * {@code POST} only changes how the first event is handed over; the listener
+	 * still re-enters the services synchronously, so the same chain has to arrive
+	 * - just later.
+	 */
+	@Test
+	void testCreateInstanz_posted_completesTheSameChainAsynchronously() {
+		_recorder.clear();
+
+		IInstanz child = _inse.createInstanz(ROOT, Type.POST);
+
+		_recorder.awaitCount(2);
+
+		assertThat(_recorder.topics(),
+				containsInAnyOrder(InstanzEventConstants.NEW, InstanzEventConstants.CHILD_LIST_CHANGE));
+		assertThat(child.getParentKey(), is(ROOT));
+		assertThat(_inse.resolveKey(ROOT).get().getChildren(), hasItem(child.getOwnKey()));
+	}
+
+	@Test
+	void testChangeValue_posted_arrivesWithItsPayload() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "old",
+				Type.SEND);
+		_recorder.clear();
+
+		assertThat(_svs.changeValue(value.getOwnKey(), "new", Type.POST), is(true));
+
+		_recorder.awaitCount(1);
+
+		assertThat(_recorder.events(), hasSize(1));
+		ValueChangeEvent changed = _recorder.onlyDataOf(SingleValueEventConstants.VALUE_CHANGE, ValueChangeEvent.class);
+		assertThat(changed._oldValue(), is("old"));
+		assertThat(changed._newValue(), is("new"));
+	}
+
+	private LinkedChildChangeEvent childListChangeOf(IInstanz instanz) {
+		return _recorder.dataOf(InstanzEventConstants.CHILD_LIST_CHANGE, LinkedChildChangeEvent.class).stream()//
+				.filter(data -> instanz.getOwnKey().equals(data._key()))//
+				.findFirst()//
+				.orElseThrow(() -> new AssertionError("no child list change for " + instanz.getOwnKey()));
+	}
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventRecorder.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventRecorder.java
@@ -1,0 +1,128 @@
+package de.tonsias.basis.osgi.test.system;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
+
+/**
+ * Listens on the same two wildcard topics as {@link IDeltaService} and keeps
+ * every event that passes, so a test can look at a whole propagation chain
+ * instead of a single call.
+ * <p>
+ * The recorded <em>order</em> is not asserted anywhere: a mutating service call
+ * is dispatched to all handlers of its topic, and whether this recorder or
+ * {@code ChangePropagationListener} - which re-enters the services and thereby
+ * produces the follow-up events - is served first is up to the event admin. The
+ * <em>set</em> of events is deterministic, and that is what the tests pin down:
+ * a missing entry means the propagation stopped early, an extra one means a
+ * loop guard did not hold.
+ * </p>
+ */
+public final class EventRecorder implements EventHandler {
+
+	/** how long {@link #awaitCount(int)} waits for asynchronously posted events */
+	private static final long TIMEOUT_MS = 5_000;
+
+	private final Object _lock = new Object();
+
+	private final List<Event> _events = new ArrayList<>();
+
+	private final IEventBrokerBridge _bridge;
+
+	private EventRecorder(IEventBrokerBridge bridge) {
+		_bridge = bridge;
+	}
+
+	/**
+	 * @return a recorder subscribed to every instanz and single value delta topic,
+	 *         headless - the tests do not run in a UI thread
+	 */
+	public static EventRecorder subscribeToAllDeltas(IEventBrokerBridge bridge) {
+		EventRecorder recorder = new EventRecorder(bridge);
+		bridge.subscribe(InstanzEventConstants.ALL_DELTA_TOPIC, recorder, true);
+		bridge.subscribe(SingleValueEventConstants.ALL_DELTA_TOPIC, recorder, true);
+		return recorder;
+	}
+
+	/**
+	 * The broker outlives the test class, so a recorder that is not detached keeps
+	 * recording the next test's events.
+	 */
+	public void unsubscribe() {
+		_bridge.unSubscribe(this);
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		synchronized (_lock) {
+			_events.add(event);
+			_lock.notifyAll();
+		}
+	}
+
+	/** drops everything recorded so far, e.g. the events of a test's set-up */
+	public void clear() {
+		synchronized (_lock) {
+			_events.clear();
+		}
+	}
+
+	public List<Event> events() {
+		synchronized (_lock) {
+			return List.copyOf(_events);
+		}
+	}
+
+	public List<String> topics() {
+		return events().stream().map(Event::getTopic).toList();
+	}
+
+	/** @return the payloads of every recorded event on that topic */
+	public <T> List<T> dataOf(String topic, Class<T> type) {
+		return events().stream()//
+				.filter(event -> topic.equals(event.getTopic()))//
+				.map(event -> type.cast(event.getProperty(IEventBroker.DATA)))//
+				.toList();
+	}
+
+	/** @return the payload of the one event expected on that topic */
+	public <T> T onlyDataOf(String topic, Class<T> type) {
+		List<T> data = dataOf(topic, type);
+		assertThat("recorded events on " + topic, data, hasSize(1));
+		return data.get(0);
+	}
+
+	/**
+	 * Waits until the given number of events has arrived, for use with
+	 * {@link IEventBrokerBridge.Type#POST}. Returns early on timeout and leaves the
+	 * missing events to the assertion that follows.
+	 */
+	public void awaitCount(int expected) {
+		long deadline = System.currentTimeMillis() + TIMEOUT_MS;
+		synchronized (_lock) {
+			while (_events.size() < expected) {
+				long remaining = deadline - System.currentTimeMillis();
+				if (remaining <= 0) {
+					return;
+				}
+				try {
+					_lock.wait(remaining);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					return;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Schließt #34.

Die Kette zwischen `InstanzServiceImpl`, `SingleValueServiceImpl` und `ChangePropagationListener` war bisher nur mit gemockten Services abgesichert. Genau diese Kette entscheidet aber, welche Dateien der `DeltaService` am Ende schreibt und löscht.

## Neu: `de.tonsias.basis.osgi.test.system`

**`EventChainSystemTest`** (24 Tests) – echte Services im OSGi-Runtime, nichts gemockt. Ein `EventRecorder` hängt auf denselben beiden Wildcard-Topics wie der `DeltaService` und zeichnet jede Kette komplett auf. Jeder Test prüft drei Dinge: welche Events entstanden sind (keins zu wenig = Propagation bricht ab, keins zu viel = ein Loop-Guard hält nicht), was die Payloads tragen, und ob danach beide Seiten der Relation übereinstimmen.

Abgedeckt: Anlegen (auch verschachtelt), Verschieben per `putChild` und per `changeParent`, Löschen eines ganzen Teilbaums, Anlegen/Verknüpfen/Ändern/Umbenennen/Löschen von SingleValues (String und Integer), jeder Guard einzeln, und die asynchrone Zustellung mit `Type.POST`.

**`DeltaPersistenceSystemTest`** (12 Tests) – dieselben Ketten durch den echten `DeltaServiceImpl`, danach wird jedes Objekt per `LoadService` frisch von der Platte gelesen. Ein verlorenes Event zeigt sich hier als fehlende oder als übrig gebliebene Datei. Enthält u. a. den Fall "Verschieben darf nichts löschen" und "Teilbaum-Löschen entfernt jede Datei".

## Nebenbei

- `E4ServiceContext` hält den erzeugten `ChangePropagationListener` jetzt fest. e4 referenziert injizierte Objekte nur schwach, der Listener konnte also mitten im Lauf eingesammelt werden und die Propagation wäre still ausgefallen.
- Beim Schreiben der Tests aufgefallen und als #35 gemeldet: Schlüssel sind Base 62 und werden unverändert zum Dateinamen, `a` und `A` sind auf Windows/macOS dieselbe Datei.

## Verifikation

`./mvnw clean verify` ist grün (278 Tests). Gegenprobe: mit entferntem Move-/Delete-Guard im `ChangePropagationListener` fallen drei der neuen Tests um – darunter der Persistenz-Test, der zeigt, dass die verschobene Instanz dann von der Platte verschwindet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)