### PR TITLE
fix #35: generate keys from a lower case only alphabet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Note that the branch `feat-2-variable_path` (issue #2) moves the interface packa
 ### Model
 `IInstanz` is the single tree node type: it has an own key, a parent key, a set of child keys, and per-`SingleValueType` `BiMap<valueKey, name>` maps of attributes. Attributes themselves are `ISingleValue` objects (`SingleStringValue`, `SingleIntegerValue`) living in their own files. **Everything is referenced by string key, never by object reference** — services resolve keys through a cache and fall back to loading from disk.
 
-`IKeyService` generates keys as a base-62 counter (`KeyServiceImpl.KEYCHARS`, incrementing least-significant char first), persisted in Eclipse instance preferences. Key `"0"` is by convention the root instanz.
+`IKeyService` generates keys as a base-36 counter (`KeyServiceImpl.KEYCHARS`, incrementing least-significant char first), persisted in Eclipse instance preferences. Key `"0"` is by convention the root instanz. The alphabet is **lower case only and must stay sorted ascending**: keys become file names as they are, so `a` and `A` would be the same file on Windows and macOS (issue #35), and `countKeyUp` looks the current char up with `Arrays.binarySearch`.
 
 ### Persistence
 JSON via Gson, one file per object, written under `Platform.getInstanceLocation()`. The path is derived from the object itself: `ISavePathOwner.getPath()` + `getOwnKey()` + `.json` (e.g. `instanz/<key>.json`, `single_value/string/<key>.json`). Services cache loaded objects in a `Map<String, …>` and only touch disk on miss or save.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Note that the branch `feat-2-variable_path` (issue #2) moves the interface packa
 ### Model
 `IInstanz` is the single tree node type: it has an own key, a parent key, a set of child keys, and per-`SingleValueType` `BiMap<valueKey, name>` maps of attributes. Attributes themselves are `ISingleValue` objects (`SingleStringValue`, `SingleIntegerValue`) living in their own files. **Everything is referenced by string key, never by object reference** — services resolve keys through a cache and fall back to loading from disk.
 
-`IKeyService` generates keys as a base-36 counter (`KeyServiceImpl.KEYCHARS`, incrementing least-significant char first), persisted in Eclipse instance preferences. Key `"0"` is by convention the root instanz. The alphabet is **lower case only and must stay sorted ascending**: keys become file names as they are, so `a` and `A` would be the same file on Windows and macOS (issue #35), and `countKeyUp` looks the current char up with `Arrays.binarySearch`.
+`IKeyService` generates keys as a base-36 counter (`KeyServiceImpl.KEYCHARS`, incrementing least-significant char first), persisted in Eclipse instance preferences. Key `"0"` is by convention the root instanz. The alphabet is **lower case only and must stay sorted ascending**.
 
 ### Persistence
 JSON via Gson, one file per object, written under `Platform.getInstanceLocation()`. The path is derived from the object itself: `ISavePathOwner.getPath()` + `getOwnKey()` + `.json` (e.g. `instanz/<key>.json`, `single_value/string/<key>.json`). Services cache loaded objects in a `Map<String, …>` and only touch disk on miss or save.

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/KeyServiceImplTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/KeyServiceImplTest.java
@@ -3,8 +3,12 @@ package de.tonsias.basis.osgi.test.impl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,11 +42,26 @@ public class KeyServiceImplTest {
 
 	@Test
 	void testInitKey_validNode() {
-		when(_pref.get(anyString(), anyString())).thenReturn("ZZ");
+		when(_pref.get(anyString(), anyString())).thenReturn("zz");
 
 		String key = _keyService.initKey();
 
-		assertThat(key, is("ZZ"));
+		assertThat(key, is("zz"));
+	}
+
+	/**
+	 * A workspace written before issue #35 can hold a key of the old base 62
+	 * alphabet, which countKeyUp() can not count up any more.
+	 */
+	@Test
+	void testInitKey_oldUpperCaseNodeIsMigrated() {
+		when(_pref.get(anyString(), anyString())).thenReturn("1A");
+
+		String key = _keyService.initKey();
+
+		assertThat(key, is("1a"));
+		verify(_pref).put(anyString(), eq("1a"));
+		assertThat(_keyService.generateKey(), is("2a"));
 	}
 
 	@Test
@@ -68,12 +87,13 @@ public class KeyServiceImplTest {
 	@ParameterizedTest
 	@CsvSource({ //
 			"a, b", //
+			"9, a", // the digits run into the letters without a gap
 			"z, 00", //
-			"aA, bA", //
+			"a1, b1", //
 			"z0, 01", //
 			"zz, 000", //
 			"2z0, 3z0", //
-			"zzT, 00U", //
+			"zzt, 00u", //
 			"zzzzz, 000000" //
 	})
 	void testGeneratekey_inArrayChange(String key, String nextKey) {
@@ -82,6 +102,24 @@ public class KeyServiceImplTest {
 		String newkey = _keyService.generateKey();
 
 		assertThat(newkey, is(nextKey));
+	}
+
+	/**
+	 * Keys become file names as they are, so an alphabet holding both cases would
+	 * make 'a' and 'A' the same file on Windows and macOS (issue #35).
+	 */
+	@Test
+	void testKeychars_holdNoUpperCase() {
+		assertThat(String.valueOf(KeyServiceImpl.KEYCHARS), is("0123456789abcdefghijklmnopqrstuvwxyz"));
+	}
+
+	/** {@link Arrays#binarySearch} only works on a sorted alphabet. */
+	@Test
+	void testKeychars_areSortedAscending() {
+		char[] sorted = KeyServiceImpl.KEYCHARS.clone();
+		Arrays.sort(sorted);
+
+		assertThat(String.valueOf(KeyServiceImpl.KEYCHARS), is(String.valueOf(sorted)));
 	}
 
 	private static class KeyServiceImplTestee extends KeyServiceImpl {

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
@@ -83,9 +83,9 @@ public class DeltaPersistenceSystemTest {
 	@Test
 	void testCreateInstanz_savesTheNewInstanzAndItsParent() {
 		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
-		// there is deliberately no "the file does not exist yet" check here: keys are
-		// base 62 and become file names as they are, so on a case insensitive file
-		// system "a" and "A" are one and the same file (see issue #35)
+		// keys are lower case only, so a brand new key can not collide with an already
+		// written file on a case insensitive file system (issue #35)
+		assertThat(Files.exists(instanzFile(child.getOwnKey())), is(false));
 
 		_delta.saveDeltas();
 

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/KeyServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/KeyServiceImpl.java
@@ -1,6 +1,7 @@
 package de.tonsias.basis.osgi.impl;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -13,10 +14,14 @@ import de.tonsias.basis.osgi.intf.IKeyService;
 @Component
 public class KeyServiceImpl implements IKeyService {
 
-	public static final char[] KEYCHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
-			'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-			'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
-			'v', 'w', 'x', 'y', 'z' };
+	/**
+	 * Base 36 - lower case only, and deliberately so: keys become file names as
+	 * they are, and on a case insensitive file system (Windows, macOS) 'a' and 'A'
+	 * would be one and the same file. Must stay sorted ascending for the
+	 * {@link Arrays#binarySearch(char[], char)} in {@link #countKeyUp(char[])}.
+	 */
+	public static final char[] KEYCHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
+			'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
 
 	private static final String KEY_KEY = "CurrentKey";
 
@@ -69,6 +74,15 @@ public class KeyServiceImpl implements IKeyService {
 		String key = node.get(KEY_KEY, "");
 		if (key.isBlank()) {
 			key = String.valueOf(KEYCHARS[0]);
+			node.put(KEY_KEY, key);
+			flush(node);
+		}
+
+		// workspaces written before issue #35 can hold a key of the old base 62
+		// alphabet, which countKeyUp() can not count up any more
+		String lowerCase = key.toLowerCase(Locale.ROOT);
+		if (!lowerCase.equals(key)) {
+			key = lowerCase;
 			node.put(KEY_KEY, key);
 			flush(node);
 		}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/KeyServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/KeyServiceImpl.java
@@ -78,8 +78,6 @@ public class KeyServiceImpl implements IKeyService {
 			flush(node);
 		}
 
-		// workspaces written before issue #35 can hold a key of the old base 62
-		// alphabet, which countKeyUp() can not count up any more
 		String lowerCase = key.toLowerCase(Locale.ROOT);
 		if (!lowerCase.equals(key)) {
 			key = lowerCase;


### PR DESCRIPTION
Closes #35.

## Problem

`KEYCHARS` was a base 62 alphabet (`0-9A-Za-z`) and keys become file names as they are (`ISavePathOwner.getPath() + getOwnKey() + ".json"`). On the case insensitive file systems of Windows and macOS `a` and `A` are therefore one and the same file — saving `a` silently overwrote `A`, loading `A` returned `a`, deleting `a` removed `A`.

## Fix

Drop the upper case block from `KEYCHARS`, leaving a base 36 counter (`0-9a-z`). The array stays sorted ascending, which `countKeyUp`'s `Arrays.binarySearch` requires.

Also lower cases a key read back from a workspace written before this change — otherwise `binarySearch` misses the upper case char and `countKeyUp` runs off the array.

The change is confined to `KeyServiceImpl`; nothing else knows the alphabet apart from `InstanzServiceImpl`, which only uses `KEYCHARS[0]` for the root key.

## Tests

- `KeyServiceImplTest`: upper case dropped from the existing cases, plus `9 -> a` for the digit/letter boundary, a guard on the alphabet itself (no upper case, sorted), and a case for the old-workspace migration.
- `DeltaPersistenceSystemTest`: the "no file before the save" check the collision forced out in #34 is back in.

`./mvnw clean verify` is green — 282 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)