### PR TITLE
feat #38: Produkt per Tycho auf der Kommandozeile bauen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    # The target platform declares win32/win32/x86_64 only, so SWT and the
+    # native launcher resolve on Windows alone. Keep this runner in sync with
+    # the <environments> in the parent pom.
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          # Highest BREE in the reactor; target-platform-configuration pins the
+          # resolution EE to JavaSE-24.
+          java-version: '24'
+          cache: maven
+
+      - name: Build bundles, run tests and materialize the product
+        run: ./mvnw --batch-mode --no-transfer-progress clean verify
+
+      - name: Upload product
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tonsias-product-win32-x86_64
+          path: de.tonsias.basis.product/target/products/*.zip
+          if-no-files-found: error
+
+      - name: Upload p2 repository
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tonsias-p2-repository
+          path: de.tonsias.basis.product/target/de.tonsias.basis.product-*.zip
+          if-no-files-found: error
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/**'
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,14 @@ Tonsias is an **Eclipse RCP / e4 desktop application** developed as an **Eclipse
 
 ## Commands
 
+```powershell
+.\build.ps1                                            # the whole pipeline: compile, test, materialize the product
+.\build.ps1 -SkipTests                                 # product only, no tests
+.\build.ps1 -- -Dtest=KeyServiceImplTest               # everything after -- goes to Maven verbatim
+```
+
+`build.ps1` is the entry point to prefer, because `JAVA_HOME` is usually not set on a dev machine: it finds a JDK 24 (`C:\dev\java`, `%ProgramFiles%\Java`, Adoptium, …), exports it and then runs the wrapper. It fails fast if it finds nothing new enough. Underneath it is plain Maven, so with a JDK 24 in `JAVA_HOME` the wrapper works directly too:
+
 ```bash
 ./mvnw clean verify                                    # compile every bundle, run all test bundles, build the product
 ./mvnw clean verify -Dmaven.test.failure.ignore=true   # keep going past failing tests to see every result
@@ -15,9 +23,23 @@ Tonsias is an **Eclipse RCP / e4 desktop application** developed as an **Eclipse
 ./mvnw clean verify -DskipTests                        # compile only
 ```
 
-Requires a JDK 24 in `JAVA_HOME` (the bundles' highest BREE). The wrapper downloads Maven itself; no local Maven install is needed.
+JDK 24 is the bundles' highest BREE and the resolution EE the target platform is pinned to; anything older fails to resolve Eclipse 4.36. The wrapper downloads Maven itself; no local Maven install is needed.
 
 **Do not use `-pl` to build a single module.** Tycho derives the reactor from the OSGi manifests, not from Maven dependencies, so `-pl <module> -am` does not pull in the bundles that module requires and fails with "Missing requirement". Build the whole reactor and narrow with `-Dtest=` instead.
+
+### Build output
+
+`de.tonsias.basis.product` has `eclipse-repository` packaging, which by itself only publishes a p2 repository. `tycho-p2-director-plugin` (configured in its pom) additionally *installs* the `tonsias` product out of that repository, which is what produces a runnable application:
+
+| Path under `de.tonsias.basis.product/target` | What it is |
+|---|---|
+| `products/tonsias/win32/win32/x86_64/Tonsias.exe` | the launcher — run this to start the built app |
+| `products/tonsias-win32.win32.x86_64.zip` | the same directory zipped, the distributable |
+| `de.tonsias.basis.product-1.0.0-SNAPSHOT.zip` | the p2 repository, for installing/updating via p2 |
+
+Only `win32/win32/x86_64` is built; add `<environment>`s to `target-platform-configuration` in the parent pom to cross-build others.
+
+`.github/workflows/build.yml` runs the same `./mvnw clean verify` on `windows-latest` for every push and PR to `main` and uploads product and p2 repository as workflow artifacts. It must stay on a Windows runner as long as the target platform declares only the win32 environment.
 
 ## Working in this repo
 
@@ -112,6 +134,6 @@ Every feature follows this sequence end to end:
 
 Never commit directly to `main`.
 
-Step 5 is `./mvnw clean verify`. The suite is **green on `main`** — 48 tests, all passing — so any failure is yours. Never "fix" one by weakening an assertion; if a test looks wrong, check it against the production code first (several once verified `post(..)` where the code had moved to `send(..)`).
+Step 5 is `.\build.ps1` (or `./mvnw clean verify`). The suite is **green on `main`** — 282 tests across the five test bundles, all passing — so any failure is yours. Never "fix" one by weakening an assertion; if a test looks wrong, check it against the production code first (several once verified `post(..)` where the code had moved to `send(..)`).
 
 Step 6 places tests in the test bundle matching the layer under test: view logic → `de.tonsias.basis.logic.test`, services → `de.tonsias.basis.osgi.test`, delta view → `de.tonsias.delta.view.ui.test`. All three run inside OSGi; prefer `@InjectMocks`/direct construction over `OsgiUtil.getService(...)`, which only resolves under a running e4 context. A new bundle's internals need `x-friends` on its `Export-Package` before its test bundle can see them.

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Builds Tonsias with Tycho and materializes the runnable product.
+
+.DESCRIPTION
+    Locates a JDK 24 (the highest BREE in the reactor), exports it as JAVA_HOME
+    for the Maven wrapper and runs the whole reactor. Everything after the
+    script's own parameters is passed on to Maven verbatim.
+
+.PARAMETER SkipTests
+    Compile and assemble only (-DskipTests).
+
+.PARAMETER Goals
+    Maven lifecycle phases to run. Defaults to "clean verify".
+
+.EXAMPLE
+    .\build.ps1
+    .\build.ps1 -SkipTests
+    .\build.ps1 -- -Dtest=KeyServiceImplTest
+#>
+[CmdletBinding()]
+param(
+    [switch] $SkipTests,
+    [string[]] $Goals = @('clean', 'verify'),
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $MavenArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# --- JDK 24 ----------------------------------------------------------------
+# The bundles' highest BREE is JavaSE-24 and target-platform-configuration pins
+# the resolution EE to it, so anything older fails to resolve Eclipse 4.36.
+# Read the version from the JDK's own "release" file rather than invoking
+# java -version: PowerShell 5.1 turns a native command's stderr into an
+# ErrorRecord, which $ErrorActionPreference = 'Stop' would make fatal.
+function Get-JdkVersion([string] $javaHome) {
+    if (-not (Test-Path (Join-Path $javaHome 'bin\java.exe'))) { return $null }
+    $releaseFile = Join-Path $javaHome 'release'
+    if (-not (Test-Path $releaseFile)) { return $null }
+    $line = Get-Content $releaseFile | Where-Object { $_ -match '^JAVA_VERSION="(\d+)' }
+    if ($line) { return [int]$Matches[1] }
+    return $null
+}
+
+function Find-Jdk24 {
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if ($env:JAVA_HOME) { $candidates.Add($env:JAVA_HOME) }
+
+    $searchRoots = @(
+        'C:\dev\java',
+        "$env:ProgramFiles\Java",
+        "$env:ProgramFiles\Eclipse Adoptium",
+        "$env:ProgramFiles\Microsoft\jdk",
+        "$env:LOCALAPPDATA\Programs\Eclipse Adoptium"
+    )
+    foreach ($root in $searchRoots) {
+        if (-not (Test-Path $root)) { continue }
+        Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            ForEach-Object { $candidates.Add($_.FullName) }
+    }
+
+    foreach ($candidate in $candidates) {
+        if ((Get-JdkVersion $candidate) -ge 24) { return $candidate }
+    }
+    return $null
+}
+
+$jdk = Find-Jdk24
+if (-not $jdk) {
+    throw "No JDK 24 or newer found. Set JAVA_HOME to one, or install it under one of: C:\dev\java, $env:ProgramFiles\Java."
+}
+$env:JAVA_HOME = $jdk
+Write-Host "JAVA_HOME = $jdk"
+
+# --- build -----------------------------------------------------------------
+# Never narrow the reactor with -pl: Tycho derives it from the OSGi manifests,
+# not from Maven dependencies, so a partial reactor fails on "Missing
+# requirement". Narrow the test run with -Dtest= instead.
+$arguments = @($Goals)
+if ($SkipTests) { $arguments += '-DskipTests' }
+if ($MavenArgs) { $arguments += ($MavenArgs | Where-Object { $_ -ne '--' }) }
+
+Write-Host "mvnw $($arguments -join ' ')"
+# Maven writes progress to stderr. When the caller redirects the script's
+# streams (".\build.ps1 2>&1 | Tee-Object build.log"), Windows PowerShell wraps
+# every such line in a NativeCommandError, which 'Stop' would make fatal
+# regardless of the exit code. Judge the build by $LASTEXITCODE instead.
+$previousPreference = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    & (Join-Path $repoRoot 'mvnw.cmd') @arguments
+} finally {
+    $ErrorActionPreference = $previousPreference
+}
+if ($LASTEXITCODE -ne 0) {
+    throw "Maven failed with exit code $LASTEXITCODE."
+}
+
+# --- report ----------------------------------------------------------------
+$productDir = Join-Path $repoRoot 'de.tonsias.basis.product\target\products\tonsias\win32\win32\x86_64'
+$launcher = Join-Path $productDir 'Tonsias.exe'
+$archives = Get-ChildItem -Path (Join-Path $repoRoot 'de.tonsias.basis.product\target\products') -Filter '*.zip' -ErrorAction SilentlyContinue
+
+Write-Host ''
+Write-Host 'BUILD OK'
+if (Test-Path $launcher) { Write-Host "  product   $launcher" }
+foreach ($archive in $archives) { Write-Host "  archive   $($archive.FullName)" }

--- a/de.tonsias.basis.product/pom.xml
+++ b/de.tonsias.basis.product/pom.xml
@@ -14,4 +14,42 @@
 	<artifactId>de.tonsias.basis.product</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<plugins>
+			<!--
+				eclipse-repository on its own only publishes a p2 repository. The
+				director installs the product uid declared in tonsias.product from
+				that repository into target/products/<uid>/<os>/<ws>/<arch>, which
+				is the runnable application incl. the native launcher, and then
+				zips it up next to the repository.
+			-->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<formats>
+						<win32>zip</win32>
+						<linux>tar.gz</linux>
+						<macosx>tar.gz</macosx>
+					</formats>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Closes #38

Bisher erzeugte `./mvnw clean verify` nur ein p2-Repository — ein lauffaehiges Produkt gab es nur ueber die IDE.

## Aenderungen

- **`de.tonsias.basis.product/pom.xml`** — `tycho-p2-director-plugin`: `materialize-products` installiert das Produkt `tonsias` aus dem p2-Repository nach `target/products/tonsias/win32/win32/x86_64`, `archive-products` zippt es.
- **`build.ps1`** — Einstiegspunkt fuer den Build. Sucht ein JDK 24 (`JAVA_HOME`, `C:\dev\java`, `%ProgramFiles%\Java`, Adoptium), setzt `JAVA_HOME` und faehrt den Wrapper. `-SkipTests`, eigene Goals und Pass-through von Maven-Argumenten.
- **`.github/workflows/build.yml`** — derselbe Build auf `windows-latest` fuer Push/PR auf `main`; laedt Produkt und p2-Repository als Artefakte hoch, bei Fehlschlag die Surefire-Reports.
- **`CLAUDE.md`** — Build-Kommandos, Ausgabepfade und Testanzahl aktualisiert.

## Verifikation

`.\build.ps1` lokal: BUILD SUCCESS, 282 Tests gruen, `Tonsias.exe` + `tonsias-win32.win32.x86_64.zip` (25 MB) erzeugt. Das gebaute Produkt wurde gestartet und laeuft.

Nur `win32/win32/x86_64` wird gebaut — das Target-Platform-Environment im Parent-POM gibt nur diese Plattform her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)