### PR TITLE
Set the reactor to 0.2.0-SNAPSHOT after the 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Tonsias are documented here. The format follows
 [semantic versioning](https://semver.org/spec/v2.0.0.html). While the major version is
 `0`, anything may still change — including the on-disk format of the model.
 
+## [Unreleased]
+
+Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
+
 ## [0.1.0] - 2026-08-07
 
 The first release. It is the point at which the model, the persistence, the event chain
@@ -93,4 +97,5 @@ is a summary of what the release contains rather than of what changed.
 - The bundles declare inconsistent Java compliance levels (19 / 22 / 24), which is why
   the build pins its resolution execution environment to `JavaSE-24`.
 
+[Unreleased]: https://github.com/Tobias-Bonsack/Tonsias/compare/v0.1.0...main
 [0.1.0]: https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Step 6 places tests in the test bundle matching the layer under test. All run in
 
 ## Releasing
 
-The current release is **0.1.0** (the first one); `CHANGELOG.md` is the per-release record and `README.md` the user-facing overview. Versions live in 37 files — every `pom.xml`, `MANIFEST.MF`, `feature.xml` and the `.product` — so never edit them by hand. Bump them with Tycho, which also rewrites the `bundle-version` lower bounds in the `Require-Bundle` of every other reactor bundle:
+The latest release is **0.1.0** (the first one) and the reactor is on **0.2.0-SNAPSHOT** behind it; `CHANGELOG.md` is the per-release record and `README.md` the user-facing overview. Versions live in 37 files — every `pom.xml`, `MANIFEST.MF`, `feature.xml` and the `.product` — so never edit them by hand. Bump them with Tycho, which also rewrites the `bundle-version` lower bounds in the `Require-Bundle` of every other reactor bundle:
 
 ```powershell
 $env:JAVA_HOME = '<jdk24>'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The build produces, under `de.tonsias.basis.product/target`:
 | ------------------------------------------------- | -------------------------------- |
 | `products/tonsias/win32/win32/x86_64/Tonsias.exe` | the launcher — run this          |
 | `products/tonsias-win32.win32.x86_64.zip`         | the distributable                |
-| `de.tonsias.basis.product-0.1.0.zip`              | the p2 repository                |
+| `de.tonsias.basis.product-<version>.zip`          | the p2 repository                |
 
 Only `win32/win32/x86_64` is built; add `<environment>`s to
 `target-platform-configuration` in the parent `pom.xml` for other platforms.

--- a/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.data.access.test
-Bundle-Version: 0.1.0
-Require-Bundle: de.tonsias.basis.data.access;bundle-version="0.1.0",
- de.tonsias.basis.model;bundle-version="0.1.0",
+Bundle-Version: 0.2.0.qualifier
+Require-Bundle: de.tonsias.basis.data.access;bundle-version="0.2.0",
+ de.tonsias.basis.model;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  org.eclipse.core.runtime;bundle-version="3.31.0",
  junit-jupiter-api;bundle-version="5.11.1",

--- a/de.tonsias.basis.data.access.test/pom.xml
+++ b/de.tonsias.basis.data.access.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access.test</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Access
 Bundle-SymbolicName: de.tonsias.basis.data.access
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.data.access.osgi.impl;x-friends:="de.tonsias.basis.data.access.test",
  de.tonsias.basis.data.access.osgi.intf
 Require-Bundle: org.osgi.service.component.annotations;bundle-version="1.5.1";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.31.0",
  com.google.guava;bundle-version="33.1.0",
  com.google.gson;bundle-version="2.10.1",
- de.tonsias.basis.model;bundle-version="0.1.0"
+ de.tonsias.basis.model;bundle-version="0.2.0"
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.data.access
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.data.access/pom.xml
+++ b/de.tonsias.basis.data.access/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.feature/feature.xml
+++ b/de.tonsias.basis.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.basis.feature"
       label="Tonsias"
-      version="0.1.0"
+      version="0.2.0.qualifier"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.basis.feature/pom.xml
+++ b/de.tonsias.basis.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.feature</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.basis.icon/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.icon/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Icon
 Bundle-SymbolicName: de.tonsias.basis.icon
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.icon
 Automatic-Module-Name: de.tonsias.basis.icon
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.icon/pom.xml
+++ b/de.tonsias.basis.icon/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.icon</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.logic.test
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Automatic-Module-Name: de.tonsias.basis.logic.test
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24
@@ -13,7 +13,7 @@ Require-Bundle: org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-params;bundle-version="5.11.1",
  org.mockito.junit-jupiter;bundle-version="5.14.0",
  org.mockito.mockito-core;bundle-version="5.14.0",
- de.tonsias.basis.logic;bundle-version="0.1.0",
+ de.tonsias.basis.logic;bundle-version="0.2.0",
  de.tonsias.basis.osgi,
  de.tonsias.basis.model,
  org.eclipse.e4.core.services;bundle-version="2.5.200"

--- a/de.tonsias.basis.logic.test/pom.xml
+++ b/de.tonsias.basis.logic.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic.test</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.basis.logic
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Automatic-Module-Name: de.tonsias.basis.logic
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.basis.logic/pom.xml
+++ b/de.tonsias.basis.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.model.test
-Bundle-Version: 0.1.0
-Require-Bundle: de.tonsias.basis.model;bundle-version="0.1.0",
+Bundle-Version: 0.2.0.qualifier
+Require-Bundle: de.tonsias.basis.model;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",

--- a/de.tonsias.basis.model.test/pom.xml
+++ b/de.tonsias.basis.model.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model.test</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model
 Bundle-SymbolicName: de.tonsias.basis.model
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.model.enums,
  de.tonsias.basis.model.impl,
  de.tonsias.basis.model.impl.value,

--- a/de.tonsias.basis.model/pom.xml
+++ b/de.tonsias.basis.model/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.osgi.test
-Bundle-Version: 0.1.0
-Require-Bundle: de.tonsias.basis.osgi;bundle-version="0.1.0",
+Bundle-Version: 0.2.0.qualifier
+Require-Bundle: de.tonsias.basis.osgi;bundle-version="0.2.0",
  org.osgi.service.event;bundle-version="1.4.1",
  org.hamcrest;bundle-version="2.2.0",
  org.eclipse.core.runtime;bundle-version="3.31.0",

--- a/de.tonsias.basis.osgi.test/pom.xml
+++ b/de.tonsias.basis.osgi.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi.test</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Osgi
 Bundle-SymbolicName: de.tonsias.basis.osgi
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.osgi.impl;x-friends:="de.tonsias.basis.osgi.test",
  de.tonsias.basis.osgi.intf,
  de.tonsias.basis.osgi.intf.non.service,
@@ -17,7 +17,7 @@ Require-Bundle: org.osgi.service.component.annotations;bundle-version="1.5.1",
  jakarta.inject.jakarta.inject-api;bundle-version="2.0.1",
  jakarta.annotation-api;bundle-version="2.1.1",
  de.tonsias.basis.model;bundle-version="0.0.0",
- de.tonsias.basis.data.access;bundle-version="0.1.0",
+ de.tonsias.basis.data.access;bundle-version="0.2.0",
  com.google.guava
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.osgi

--- a/de.tonsias.basis.osgi/pom.xml
+++ b/de.tonsias.basis.osgi/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.product/pom.xml
+++ b/de.tonsias.basis.product/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.product</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<build>

--- a/de.tonsias.basis.product/tonsias.product
+++ b/de.tonsias.basis.product/tonsias.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.1.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.2.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>

--- a/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: i18n
 Bundle-SymbolicName: de.tonsias.basis.ui.i18n
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.ui.i18n;x-friends:="de.tonsias.basis.ui"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0"
 Automatic-Module-Name: de.tonsias.basis.ui.i18n

--- a/de.tonsias.basis.ui.i18n/pom.xml
+++ b/de.tonsias.basis.ui.i18n/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui.i18n</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: de.tonsias.basis.ui;singleton:=true
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.jface;bundle-version="3.33.0",
  org.eclipse.e4.core.di;bundle-version="1.9.300",
@@ -12,17 +12,17 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.e4.core.contexts;bundle-version="1.12.500",
  jakarta.inject.jakarta.inject-api;bundle-version="2.0.1",
  jakarta.annotation-api;bundle-version="2.1.1",
- de.tonsias.basis.osgi;bundle-version="0.1.0",
- de.tonsias.basis.model;bundle-version="0.1.0",
+ de.tonsias.basis.osgi;bundle-version="0.2.0",
+ de.tonsias.basis.model;bundle-version="0.2.0",
  com.google.guava,
  org.osgi.service.component;bundle-version="1.5.1",
  org.eclipse.e4.core.services,
  org.eclipse.e4.ui.model.workbench;bundle-version="2.4.200",
- de.tonsias.basis.logic;bundle-version="0.1.0",
+ de.tonsias.basis.logic;bundle-version="0.2.0",
  org.osgi.service.event;bundle-version="1.4.1",
  de.tonsias.basis.ui.i18n,
  org.eclipse.jface.notifications;bundle-version="0.7.400",
- de.tonsias.basis.icon;bundle-version="0.1.0"
+ de.tonsias.basis.icon;bundle-version="0.2.0"
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.ui
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.ui/pom.xml
+++ b/de.tonsias.basis.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.feature/feature.xml
+++ b/de.tonsias.delta.view.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.delta.view.feature"
       label="Tonsias Delta View"
-      version="0.1.0"
+      version="0.2.0.qualifier"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.delta.view.feature/pom.xml
+++ b/de.tonsias.delta.view.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.feature</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.delta.view.logic
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Automatic-Module-Name: de.tonsias.delta.view.logic
 Bundle-RequiredExecutionEnvironment: JavaSE-22

--- a/de.tonsias.delta.view.logic/pom.xml
+++ b/de.tonsias.delta.view.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.logic</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui.i18n/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui.i18n/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: I18n
 Bundle-SymbolicName: de.tonsias.delta.view.ui.i18n
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.delta.view.ui.i18n
 Automatic-Module-Name: de.tonsias.delta.view.ui.i18n
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.delta.view.ui.i18n/pom.xml
+++ b/de.tonsias.delta.view.ui.i18n/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui.i18n</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.delta.view.ui.test
-Bundle-Version: 0.1.0
-Require-Bundle: de.tonsias.delta.view.ui;bundle-version="0.1.0",
+Bundle-Version: 0.2.0.qualifier
+Require-Bundle: de.tonsias.delta.view.ui;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",

--- a/de.tonsias.delta.view.ui.test/pom.xml
+++ b/de.tonsias.delta.view.ui.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui.test</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DeltaViewUI
 Bundle-SymbolicName: de.tonsias.delta.view.ui
-Bundle-Version: 0.1.0
+Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.delta.view.ui;x-friends:="de.tonsias.delta.vi
  ew.ui.test",de.tonsias.delta.view.ui.tree;x-friends:="de.tonsias.delta.
  view.ui.test"
@@ -17,10 +17,10 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="2.4.200.v20240
  jakarta.inject.jakarta.inject-api,
  jakarta.annotation-api,
  de.tonsias.basis.osgi,
- de.tonsias.delta.view.ui.i18n;bundle-version="0.1.0",
+ de.tonsias.delta.view.ui.i18n;bundle-version="0.2.0",
  org.osgi.service.event;bundle-version="1.4.1",
- de.tonsias.delta.view.logic;bundle-version="0.1.0",
- de.tonsias.basis.icon;bundle-version="0.1.0"
+ de.tonsias.delta.view.logic;bundle-version="0.2.0",
+ de.tonsias.basis.icon;bundle-version="0.2.0"
 Automatic-Module-Name: de.tonsias.delta.view.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.delta.view.ui/pom.xml
+++ b/de.tonsias.delta.view.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>de.tonsias</groupId>
 	<artifactId>de.tonsias.parent</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Tonsias</name>
@@ -60,7 +60,7 @@
 						<artifact>
 							<groupId>de.tonsias</groupId>
 							<artifactId>target-platform</artifactId>
-							<version>0.1.0</version>
+							<version>0.2.0-SNAPSHOT</version>
 						</artifact>
 					</target>
 					<!--

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.1.0</version>
+		<version>0.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>target-platform</artifactId>
-	<version>0.1.0</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-target-definition</packaging>
 </project>


### PR DESCRIPTION
`v0.1.0` is tagged and [released](https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.1.0), so development behind the tag should no longer claim to be the released version.

`tycho-versions-plugin:set-version -DnewVersion=0.2.0-SNAPSHOT -DupdateVersionRangeMatchingBounds=true` moves every `pom.xml`, `MANIFEST.MF`, `feature.xml` and the `.product` to `0.2.0-SNAPSHOT` / `0.2.0.qualifier`. Unlike the 0.1.0 bump it rewrites `tonsias.product` on its own, because the `version` attribute now matches the version being replaced.

Alongside it:

- `CHANGELOG.md` gets an `Unreleased` section and the compare link.
- The build output table in `README.md` loses the fixed `0.1.0` from the p2 repository file name, where it would go stale on every bump. The asset names in the download section stay at `0.1.0` — they name what the 0.1.0 release actually contains.
- `CLAUDE.md` records that the reactor sits on `0.2.0-SNAPSHOT` behind the 0.1.0 tag.

`.\build.ps1` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)