### PR TITLE
chore license-metadata: declare MIT in the reactor and scope it in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,8 @@ package is exported to the test bundle alone.
 ## License
 
 [MIT](LICENSE) © 2025 Tobias-Bonsack
+
+That covers the `de.tonsias.*` bundles. The built product is an aggregate: the zip under
+`de.tonsias.basis.product/target` also contains the Eclipse Platform bundles, which are
+[EPL-2.0](https://www.eclipse.org/legal/epl-2.0/) and stay under their own terms — each
+one carries its `about.html` inside its jar. Guava and Gson are Apache-2.0.

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,15 @@
 	<packaging>pom</packaging>
 
 	<name>Tonsias</name>
+	<url>https://github.com/Tobias-Bonsack/Tonsias</url>
+
+	<licenses>
+		<license>
+			<name>MIT License</name>
+			<url>https://github.com/Tobias-Bonsack/Tonsias/blob/main/LICENSE</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<properties>
 		<tycho.version>5.0.3</tycho.version>


### PR DESCRIPTION
The `LICENSE` file, the README and both `feature.xml` already named MIT — the parent pom did not, so nothing reading Maven metadata could see it.

- `pom.xml`: add `<licenses>` (MIT, pointing at the LICENSE file) and the project `<url>` to `de.tonsias.parent`. All 18 modules inherit it, so no per-module edit.
- `README.md`: note that MIT covers the `de.tonsias.*` bundles. The product zip is an aggregate and also ships the Eclipse Platform under EPL-2.0 (each bundle carries its own `about.html`); Guava and Gson are Apache-2.0.

No code or build behaviour changes. Verified with `./mvnw validate` — the whole reactor still parses and resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)