### PR TITLE
feat boolean-value-type: add a boolean SingleValueType

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,14 +11,21 @@
     Compile and assemble only (-DskipTests).
 
 .PARAMETER Goals
-    Maven lifecycle phases to run. Defaults to "clean verify".
+    Maven lifecycle phases to run. Defaults to "clean verify". Named only -
+    see the note on PositionalBinding below.
 
 .EXAMPLE
     .\build.ps1
     .\build.ps1 -SkipTests
     .\build.ps1 -- -Dtest=KeyServiceImplTest
+    .\build.ps1 -Goals clean,test
 #>
-[CmdletBinding()]
+# PositionalBinding is off so that everything the caller adds ends up in
+# MavenArgs. On by default, PowerShell binds the arguments after "--"
+# positionally to the first parameter that takes them - which is Goals, and
+# Maven then aborts with "No goals have been specified" because the default
+# "clean verify" was overwritten by the -D flag.
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [switch] $SkipTests,
     [string[]] $Goals = @('clean', 'verify'),

--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/LoadServiceImplTest.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/LoadServiceImplTest.java
@@ -1,6 +1,7 @@
 package de.tonsias.basis.data.access.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
@@ -14,6 +15,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import de.tonsias.basis.data.access.osgi.impl.LoadServiceImpl;
 import de.tonsias.basis.data.access.osgi.impl.SaveServiceImpl;
@@ -59,14 +62,34 @@ public class LoadServiceImplTest {
 		Instanz saved = new Instanz("load_bimap");
 		saved.addValuekeys(SingleValueType.SINGLE_STRING, java.util.Map.entry("sKey", "sName"));
 		saved.addValuekeys(SingleValueType.SINGLE_INTEGER, java.util.Map.entry("iKey", "iName"));
+		saved.addValuekeys(SingleValueType.SINGLE_BOOLEAN, java.util.Map.entry("bKey", "bName"));
 
 		_saveService.safeAsGson(saved, saved.getClass());
 		IInstanz loaded = _loadService.loadFromGson("instanz/load_bimap", Instanz.class);
 
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_STRING), hasEntry("sKey", "sName"));
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_INTEGER), hasEntry("iKey", "iName"));
+		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_BOOLEAN), hasEntry("bKey", "bName"));
 		// the inverse view is what TreeLabelProvider looks a name up in
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_STRING).inverse().get("sName"), is("sKey"));
+	}
+
+	/**
+	 * A file written before a {@code SingleValueType} existed carries no map for it,
+	 * and Gson constructs the instanz without running any field initializer. Every
+	 * type still has to answer with a usable map - {@code TreeNodeWrapper} and
+	 * {@code InstanzView} walk all of them and would fail on a null.
+	 */
+	@ParameterizedTest
+	@EnumSource(SingleValueType.class)
+	void testLoadFromGson_mapsMissingFromTheJsonAreEmptyNotNull(SingleValueType type) throws IOException {
+		Path file = InstanceLocation.resolve("instanz/load_legacy.json");
+		Files.createDirectories(file.getParent());
+		Files.writeString(file, "{\"_ownKey\":\"load_legacy\",\"_parentKey\":\"0\",\"_childKeys\":[]}");
+
+		IInstanz loaded = _loadService.loadFromGson("instanz/load_legacy", Instanz.class);
+
+		assertThat(loaded.getSingleValues(type), is(anEmptyMap()));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/enums/SingleValueTypeTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/enums/SingleValueTypeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -29,6 +30,12 @@ public class SingleValueTypeTest {
 	void testGetByClass_integerValue() {
 		assertThat(SingleValueType.getByClass(SingleIntegerValue.class),
 				is(Optional.of(SingleValueType.SINGLE_INTEGER)));
+	}
+
+	@Test
+	void testGetByClass_booleanValue() {
+		assertThat(SingleValueType.getByClass(SingleBooleanValue.class),
+				is(Optional.of(SingleValueType.SINGLE_BOOLEAN)));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/impl/AInstanzTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/impl/AInstanzTest.java
@@ -1,6 +1,7 @@
 package de.tonsias.basis.model.test.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -99,6 +100,16 @@ public class AInstanzTest {
 	@EnumSource(SingleValueType.class)
 	void testGetSingleValues_sameMapPerType(SingleValueType type) {
 		assertThat(_instanz.getSingleValues(type), is(sameInstance(_instanz.getSingleValues(type))));
+	}
+
+	/**
+	 * The maps are created on demand rather than by a field initializer, because
+	 * Gson skips those. Every type has to answer with a usable map from the start.
+	 */
+	@ParameterizedTest
+	@EnumSource(SingleValueType.class)
+	void testGetSingleValues_isEmptyNotNullOnANewInstanz(SingleValueType type) {
+		assertThat(_instanz.getSingleValues(type), is(anEmptyMap()));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleBooleanValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleBooleanValueTest.java
@@ -1,0 +1,85 @@
+package de.tonsias.basis.model.test.value;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+
+public class SingleBooleanValueTest {
+
+	@Test
+	void testNewValue_startsAtFalse() {
+		assertThat(new SingleBooleanValue("k").getValue(), is(false));
+	}
+
+	@Test
+	void testGetPath_matchesTheEnum() {
+		assertThat(new SingleBooleanValue("k").getPath(), is(SingleValueType.SINGLE_BOOLEAN.getPath()));
+	}
+
+	@Test
+	void testTryToSetValue_boolean() {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+
+		assertThat(value.tryToSetValue(true), is(true));
+		assertThat(value.getValue(), is(true));
+	}
+
+	@Test
+	void testTryToSetValue_sameBooleanIsNoChange() {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+		value.tryToSetValue(true);
+
+		assertThat(value.tryToSetValue(true), is(false));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "true, true", "false, false", "TRUE, true", "False, false", "'  true  ', true" })
+	void testTryToSetValue_parsableString(String input, boolean expected) {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+		// false is the default, so the false cases need a different starting point to
+		// tell "was set" from "was already there"
+		value.tryToSetValue(!expected);
+
+		assertThat(value.tryToSetValue(input), is(true));
+		assertThat(value.getValue(), is(expected));
+	}
+
+	/**
+	 * Anything that is not one of the two literals is rejected rather than folded
+	 * into {@code false} - a typo must not silently clear the value.
+	 */
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(strings = { "", "  ", "ja", "yes", "1", "0" })
+	void testTryToSetValue_unparsableInputIsRejected(Object input) {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+		value.tryToSetValue(true);
+
+		assertThat(value.tryToSetValue(input), is(false));
+		assertThat(value.getValue(), is(true));
+	}
+
+	@Test
+	void testTryToSetValue_numberIsRejected() {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+
+		assertThat(value.tryToSetValue(1), is(false));
+		assertThat(value.getValue(), is(false));
+	}
+
+	@Test
+	void testToString_containsKeyValueAndSimpleClassName() {
+		SingleBooleanValue value = new SingleBooleanValue("k");
+		value.tryToSetValue(true);
+
+		assertThat(value.toString(), is("k true : SingleBooleanValue"));
+	}
+}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
@@ -3,14 +3,18 @@ package de.tonsias.basis.model.enums;
 import java.util.Arrays;
 import java.util.Optional;
 
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
 
 public enum SingleValueType {
 
+	// new constants belong at the end - CreateInstanzDialog maps its combo box onto
+	// the ordinals, so reordering would move existing selections
 	SINGLE_STRING(SingleStringValue.class, "single_value/string/"),
-	SINGLE_INTEGER(SingleIntegerValue.class, "single_value/integer/");
+	SINGLE_INTEGER(SingleIntegerValue.class, "single_value/integer/"),
+	SINGLE_BOOLEAN(SingleBooleanValue.class, "single_value/boolean/");
 
 	private final Class<? extends ISingleValue<?>> _clazz;
 

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -30,9 +30,14 @@ public abstract class AInstanz implements IInstanz {
 
 	private Set<String> _childKeys = Collections.synchronizedSet(new HashSet<String>());
 
-	private BiMap<String, String> _singleStringKeyValueMap = HashBiMap.create();
+	// no field initializers: Gson constructs an AInstanz without a constructor and
+	// would leave a map absent from the json at null. getSingleValues is therefore
+	// the single place that creates one, for every type alike.
+	private BiMap<String, String> _singleStringKeyValueMap;
 
-	private BiMap<String, String> _singleIntegerKeyValueMap = HashBiMap.create();
+	private BiMap<String, String> _singleIntegerKeyValueMap;
+
+	private BiMap<String, String> _singleBooleanKeyValueMap;
 
 	public AInstanz(String key) {
 		this._ownKey = key;
@@ -44,12 +49,14 @@ public abstract class AInstanz implements IInstanz {
 	}
 
 	public AInstanz(String _parentKey, String _ownKey, Set<String> _childKeys,
-			BiMap<String, String> _singleStringKeyValueMap, BiMap<String, String> _singleIntegerKeyValueMap) {
+			BiMap<String, String> _singleStringKeyValueMap, BiMap<String, String> _singleIntegerKeyValueMap,
+			BiMap<String, String> _singleBooleanKeyValueMap) {
 		this._parentKey = _parentKey;
 		this._ownKey = _ownKey;
 		this._childKeys = _childKeys;
 		this._singleStringKeyValueMap = _singleStringKeyValueMap;
 		this._singleIntegerKeyValueMap = _singleIntegerKeyValueMap;
+		this._singleBooleanKeyValueMap = _singleBooleanKeyValueMap;
 	}
 
 	@Override
@@ -104,9 +111,20 @@ public abstract class AInstanz implements IInstanz {
 	public BiMap<String, String> getSingleValues(SingleValueType type) {
 		switch (type) {
 		case SINGLE_STRING:
+			if (_singleStringKeyValueMap == null) {
+				_singleStringKeyValueMap = HashBiMap.create();
+			}
 			return _singleStringKeyValueMap;
 		case SINGLE_INTEGER:
+			if (_singleIntegerKeyValueMap == null) {
+				_singleIntegerKeyValueMap = HashBiMap.create();
+			}
 			return _singleIntegerKeyValueMap;
+		case SINGLE_BOOLEAN:
+			if (_singleBooleanKeyValueMap == null) {
+				_singleBooleanKeyValueMap = HashBiMap.create();
+			}
+			return _singleBooleanKeyValueMap;
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleBooleanValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleBooleanValue.java
@@ -1,0 +1,53 @@
+package de.tonsias.basis.model.impl.value;
+
+import java.util.Set;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+
+public class SingleBooleanValue extends ASingleValue<Boolean> {
+
+	public SingleBooleanValue(String key) {
+		super(key);
+		this.setValue(Boolean.FALSE);
+	}
+
+	public SingleBooleanValue(String key, boolean value, Set<String> connectedInstanzes) {
+		super(key, value, connectedInstanzes);
+	}
+
+	/**
+	 * Only the two literals are accepted - anything else is rejected instead of
+	 * being folded into {@code false}, so a typo does not silently clear the value.
+	 */
+	@Override
+	public boolean tryToSetValue(Object value) {
+		if (value instanceof Boolean b) {
+			return setValue(b);
+		} else if (value instanceof String s) {
+			String trimmed = s.strip();
+			if (Boolean.TRUE.toString().equalsIgnoreCase(trimmed)) {
+				return setValue(Boolean.TRUE);
+			}
+			if (Boolean.FALSE.toString().equalsIgnoreCase(trimmed)) {
+				return setValue(Boolean.FALSE);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String getPath() {
+		return SingleValueType.SINGLE_BOOLEAN.getPath();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(this.getOwnKey()).append(" ");
+		builder.append(this.getValue()).append(" ");
+		String[] string = this.getClass().toString().split("\\.");
+		builder.append(": ").append(string[string.length - 1]);
+		return builder.toString();
+	}
+
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplUnitTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/impl/SingleValueServiceImplUnitTest.java
@@ -37,6 +37,7 @@ import de.tonsias.basis.data.access.osgi.intf.DeleteService;
 import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -149,6 +150,19 @@ public class SingleValueServiceImplUnitTest {
 
 		assertThat(created, is(instanceOf(SingleIntegerValue.class)));
 		assertThat(created.getValue(), is(42));
+	}
+
+	@Test
+	void testCreateNew_booleanValue() {
+		when(_keyService.generateKey()).thenReturn("key");
+
+		SingleBooleanValue created = _service.createNew(SingleBooleanValue.class, "owner", "paramName", true,
+				Type.SEND);
+
+		assertThat(created, is(instanceOf(SingleBooleanValue.class)));
+		assertThat(created.getValue(), is(true));
+		verify(_broker).send(SingleValueEventConstants.NEW, Map.of(IEventBroker.DATA, new SingleValueNewEvent(
+				SingleValueType.SINGLE_BOOLEAN, "key", "paramName", List.of("owner"))));
 	}
 
 	@Test

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -525,6 +526,25 @@ public class EventChainSystemTest {
 
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_INTEGER).get(value.getOwnKey()), is("number"));
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).keySet(), is(empty()));
+	}
+
+	/** The same for the third type, whose value travels as a {@code Boolean}. */
+	@Test
+	void testCreateSingleValue_boolean_usesItsOwnTypeThroughoutTheChain() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		SingleBooleanValue value = _svs.createNew(SingleBooleanValue.class, owner.getOwnKey(), "flag", true, Type.SEND);
+
+		assertThat(value.getValue(), is(true));
+		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
+				is(SingleValueType.SINGLE_BOOLEAN));
+		assertThat(_recorder.onlyDataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class)
+				._singleValuetype(), is(SingleValueType.SINGLE_BOOLEAN));
+
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_BOOLEAN).get(value.getOwnKey()), is("flag"));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).keySet(), is(empty()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_INTEGER).keySet(), is(empty()));
 	}
 
 	/**

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -23,6 +23,7 @@ import de.tonsias.basis.data.access.osgi.intf.DeleteService;
 import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -117,6 +118,8 @@ public class SingleValueServiceImpl implements ISingleValueService {
 			return (E) new SingleStringValue(key);
 		case SINGLE_INTEGER:
 			return (E) new SingleIntegerValue(key);
+		case SINGLE_BOOLEAN:
+			return (E) new SingleBooleanValue(key);
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
@@ -11,6 +11,7 @@ constant_parent        = Parent
 constant_remove        = Remove
 constant_save          = Save
 constant_singleValue   = Single Value
+constant_type_boolean  = Boolean
 constant_type_integer  = Integer
 constant_type_string   = String
 constant_value         = Value

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
@@ -11,6 +11,7 @@ constant_parent        = Elternelement
 constant_remove        = Entfernen
 constant_save          = Speichern
 constant_singleValue   = Einzelwert
+constant_type_boolean  = Wahrheitswert
 constant_type_integer  = Ganzzahl
 constant_type_string   = Text
 constant_value         = Wert

--- a/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
+++ b/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
@@ -13,6 +13,7 @@ public class Messages {
 	public String constant_remove;
 	public String constant_save;
 	public String constant_singleValue;
+	public String constant_type_boolean;
 	public String constant_type_integer;
 	public String constant_type_string;
 	public String constant_value;

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
@@ -19,6 +19,7 @@ class MessagesUtilTest {
 		Messages messages = new Messages();
 		messages.constant_type_string = "String";
 		messages.constant_type_integer = "Integer";
+		messages.constant_type_boolean = "Boolean";
 		messages.pref_currentKey = "Current key";
 		messages.pref_modelViewText = "Model view text";
 		messages.pref_enableValues = "Enable values";
@@ -32,6 +33,7 @@ class MessagesUtilTest {
 
 		assertEquals("String", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_STRING));
 		assertEquals("Integer", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_INTEGER));
+		assertEquals("Boolean", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_BOOLEAN));
 	}
 
 	/**

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
@@ -30,7 +30,12 @@ import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.ui.i18n.Messages;
 
-public abstract class AValueDialog<T extends ISingleValue<?>> extends Dialog {
+/**
+ * @param <T> the edited value
+ * @param <C> the SWT widget this value is entered with - the subclass names it,
+ *            so it works on its own widget without casting
+ */
+public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control> extends Dialog {
 
 	IKeyService _keyService = OsgiUtil.getService(IKeyService.class);
 
@@ -44,7 +49,7 @@ public abstract class AValueDialog<T extends ISingleValue<?>> extends Dialog {
 
 	Text _nameText;
 
-	Text _valueText;
+	C _valueControl;
 
 	SingleValueType _type;
 
@@ -147,12 +152,14 @@ public abstract class AValueDialog<T extends ISingleValue<?>> extends Dialog {
 		GridDataFactory.fillDefaults().applyTo(valueLabel);
 
 		String valueString = _value.map(v -> v.getValue().toString()).orElse("");
-		_valueText = getValueText(composite, valueString);
+		_valueControl = createValueControl(composite, valueString);
 	}
 
-	protected Text getValueText(Composite composite, String valueString) {
-		return TextFactory.newText(SWT.None).text(valueString).layoutData(GridDataFactory.fillDefaults().grab(true, false).create()).enabled(true).create(composite);
-	}
+	/**
+	 * Creates the widget the value is entered with. The subclass decides its type
+	 * and prefills it from {@code valueString}, which is empty for a new value.
+	 */
+	protected abstract C createValueControl(Composite composite, String valueString);
 
 	public T getSingleValue() {
 		return _value.get();

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/BooleanValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/BooleanValueDialog.java
@@ -1,0 +1,64 @@
+package de.tonsias.basis.ui.dialog;
+
+import java.util.Optional;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.widgets.ButtonFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.ui.i18n.Messages;
+
+public class BooleanValueDialog extends AValueDialog<SingleBooleanValue, Button> {
+
+	public BooleanValueDialog(Shell parentShell, SingleBooleanValue booleanValue, IInstanz instanz, Messages messages) {
+		super(parentShell, booleanValue, instanz, messages);
+	}
+
+	public BooleanValueDialog(Shell parentShell, IInstanz instanz, Messages messages) {
+		this(parentShell, null, instanz, messages);
+	}
+
+	/**
+	 * A check box cannot hold an invalid state, so unlike the other dialogs this one
+	 * needs no validating listener on top of the name check of the base class.
+	 */
+	@Override
+	protected Button createValueControl(Composite composite, String valueString) {
+		Button check = ButtonFactory.newButton(SWT.CHECK)//
+				.text("")//
+				.layoutData(GridDataFactory.fillDefaults().grab(true, false).create())//
+				.create(composite);
+		// empty for a new value, which parses to false - the default of the model too
+		check.setSelection(Boolean.parseBoolean(valueString));
+		return check;
+	}
+
+	@Override
+	protected void okPressed() {
+		if (_value.isEmpty()) {
+			_value = Optional.of(//
+					_sVService.createNew(SingleBooleanValue.class, //
+							_instanz.getOwnKey(), //
+							_nameText.getText(), //
+							_valueControl.getSelection(), //
+							IEventBrokerBridge.Type.POST//
+					));
+		} else {
+			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
+					IEventBrokerBridge.Type.POST);
+		}
+		super.okPressed();
+	}
+
+	@Override
+	SingleValueType getType() {
+		return SingleValueType.SINGLE_BOOLEAN;
+	}
+}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
@@ -3,9 +3,13 @@ package de.tonsias.basis.ui.dialog;
 import java.util.Optional;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.widgets.TextFactory;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
@@ -13,7 +17,7 @@ import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
-public class IntegerValueDialog extends AValueDialog<SingleIntegerValue> {
+public class IntegerValueDialog extends AValueDialog<SingleIntegerValue, Text> {
 
 	public IntegerValueDialog(Shell parentShell, SingleIntegerValue stringValue, IInstanz instanz, Messages messages) {
 		super(parentShell, stringValue, instanz, messages);
@@ -24,13 +28,19 @@ public class IntegerValueDialog extends AValueDialog<SingleIntegerValue> {
 	}
 
 	@Override
+	protected Text createValueControl(Composite composite, String valueString) {
+		return TextFactory.newText(SWT.None).text(valueString)
+				.layoutData(GridDataFactory.fillDefaults().grab(true, false).create()).enabled(true).create(composite);
+	}
+
+	@Override
 	protected Control createDialogArea(Composite parent) {
 		Control control = super.createDialogArea(parent);
 
-		_valueText.addModifyListener(event -> {
-			if (_valueText.getText().isBlank() || !isInteger(_valueText.getText())) {
+		_valueControl.addModifyListener(event -> {
+			if (_valueControl.getText().isBlank() || !isInteger(_valueControl.getText())) {
 				getButton(IDialogConstants.OK_ID).setEnabled(false);
-			} else if (isInteger(_valueText.getText())) {
+			} else if (isInteger(_valueControl.getText())) {
 				getButton(IDialogConstants.OK_ID).setEnabled(true);
 			}
 		});
@@ -45,7 +55,7 @@ public class IntegerValueDialog extends AValueDialog<SingleIntegerValue> {
 					_sVService.createNew(SingleIntegerValue.class, //
 							_instanz.getOwnKey(), //
 							_nameText.getText(), //
-							_valueText.getText(), //
+							_valueControl.getText(), //
 							IEventBrokerBridge.Type.POST//
 					));
 		} else {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/StringValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/StringValueDialog.java
@@ -17,7 +17,7 @@ import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
-public class StringValueDialog extends AValueDialog<SingleStringValue> {
+public class StringValueDialog extends AValueDialog<SingleStringValue, Text> {
 
 	public StringValueDialog(Shell parentShell, SingleStringValue stringValue, IInstanz instanz, Messages messages) {
 		super(parentShell, stringValue, instanz, messages);
@@ -34,7 +34,7 @@ public class StringValueDialog extends AValueDialog<SingleStringValue> {
 					_sVService.createNew(SingleStringValue.class, //
 							_instanz.getOwnKey(), //
 							_nameText.getText(), //
-							_valueText.getText(), //
+							_valueControl.getText(), //
 							IEventBrokerBridge.Type.POST//
 					));
 		} else {
@@ -51,7 +51,7 @@ public class StringValueDialog extends AValueDialog<SingleStringValue> {
 	}
 	
 	@Override
-	protected Text getValueText(Composite composite, String valueString) {
+	protected Text createValueControl(Composite composite, String valueString) {
 		Text text = TextFactory.newText(SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL).layoutData(GridDataFactory.fillDefaults().grab(true, true).create()).text(valueString).enabled(true).create(composite);
 		text.addKeyListener(new KeyAdapter() {
 			@Override

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
@@ -11,6 +11,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.widgets.ButtonFactory;
 import org.eclipse.jface.widgets.LabelFactory;
 import org.eclipse.jface.widgets.TextFactory;
 import org.eclipse.swt.SWT;
@@ -19,6 +20,8 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
@@ -200,6 +203,20 @@ public class InstanzView {
 					.layoutData(GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 100).create())//
 					.create(typeGroup);
 			break;
+		case SINGLE_BOOLEAN:
+			Button check = ButtonFactory.newButton(SWT.CHECK)//
+					.text("")//
+					.layoutData(GridDataFactory.fillDefaults().grab(true, false).create())//
+					.create(typeGroup);
+			check.setSelection(Boolean.TRUE.equals(singleValue.getValue()));
+			check.addSelectionListener(SelectionListener
+					.widgetSelectedAdapter(event -> onSingleValueSelect(singleValue, check)));
+			control = check;
+			break;
+		default:
+			// without a widget the listener below would fail on null - a new type has to
+			// bring its own case rather than break the whole view
+			throw new IllegalArgumentException("Unexpected value: " + singleValue.getClass());
 		}
 		createSaveKeyListener(control);
 
@@ -252,6 +269,21 @@ public class InstanzView {
 		Text text = (Text) event.widget;
 		text.setBackground(text.getDisplay().getSystemColor(SWT.COLOR_GREEN));
 		_logic.createModifySvJob(singleValue.getOwnKey(), text.getText());
+		_part.setDirty(true);
+	}
+
+	/**
+	 * The check box counterpart of {@link #onSingleValueModify} - a selection
+	 * carries its state on the widget instead of in the event, and the value goes
+	 * to the job as a {@link Boolean} rather than as text.
+	 */
+	private void onSingleValueSelect(ISingleValue<?> singleValue, Button check) {
+		if (_logic.isInDelete(singleValue)) {
+			return;
+		}
+
+		check.setBackground(check.getDisplay().getSystemColor(SWT.COLOR_GREEN));
+		_logic.createModifySvJob(singleValue.getOwnKey(), check.getSelection());
 		_part.setDirty(true);
 	}
 

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.osgi.service.event.Event;
 
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -46,6 +47,7 @@ import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent
 import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.osgi.intf.non.service.PreferenceEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
+import de.tonsias.basis.ui.dialog.BooleanValueDialog;
 import de.tonsias.basis.ui.dialog.IntegerValueDialog;
 import de.tonsias.basis.ui.dialog.StringValueDialog;
 import de.tonsias.basis.ui.handler.CreateInstanzOperation;
@@ -257,6 +259,31 @@ public class ModelView {
 				int open = dialog.open();
 				if (open == Window.OK) {
 					SingleIntegerValue singleValue = dialog.getSingleValue();
+					new TreeNodeWrapper(singleValue, parent);
+					_treeViewer.refresh(parent);
+				}
+
+			}
+		});
+
+		MenuItem createBooleanValueItem = new MenuItem(singleValueMenu, SWT.None);
+		createBooleanValueItem.setText(_messages.constant_type_boolean);
+
+		createBooleanValueItem.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				TreeItem[] selection = tree.getSelection();
+				if (selection.length != 1) {
+					return;
+				}
+
+				TreeNodeWrapper parent = (TreeNodeWrapper) selection[0].getData();
+				IInstanz parentObject = (IInstanz) parent.getObject();
+
+				BooleanValueDialog dialog = new BooleanValueDialog(new Shell(), parentObject, _messages);
+				int open = dialog.open();
+				if (open == Window.OK) {
+					SingleBooleanValue singleValue = dialog.getSingleValue();
 					new TreeNodeWrapper(singleValue, parent);
 					_treeViewer.refresh(parent);
 				}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
@@ -21,6 +21,8 @@ public class MessagesUtil {
 			return messages.constant_type_string;
 		case SINGLE_INTEGER:
 			return messages.constant_type_integer;
+		case SINGLE_BOOLEAN:
+			return messages.constant_type_boolean;
 		default:
 			return type.name();
 		}


### PR DESCRIPTION
Adds `SINGLE_BOOLEAN` as the third `SingleValueType`, edited through a check box.

Persistence and the event flow needed nothing: `SaveServiceImpl`/`LoadServiceImpl` work reflectively over Gson and derive the path from `ISavePathOwner.getPath()`, the `SingleValueEventConstants` records carry the type as a field, and `ChangePropagationListener`, `DeltaServiceImpl` and the `de.tonsias.delta.view.*` bundles contain no type-specific branch at all. The change is four switches plus the UI.

## Model

- `SingleBooleanValue extends ASingleValue<Boolean>`, path `single_value/boolean/`. `tryToSetValue` takes a `Boolean` or the two literals as text, and rejects everything else instead of folding it into `false`.
- The constant is appended: `CreateInstanzDialog` maps its combo box onto the ordinals.
- `AInstanz` gets the matching `BiMap` — and all three move from a field initializer to being created on demand. Gson builds an `AInstanz` without a constructor, so a map absent from an older `instanz/*.json` stayed `null`, and `TreeNodeWrapper` and `InstanzView` walk every type. Existing files stay readable.

## UI

- `AValueDialog<T, C extends Control>` — the second parameter is the widget the value is entered with, so each subclass works on its own widget without a cast (`Text`, `Text`, `Button`). The `getValueText` hook is gone; its default single-line field moved into `IntegerValueDialog`.
- `InstanzView` renders a check box and routes it through a new `onSingleValueSelect`; the existing handler casts `event.widget` to `Text`. The value reaches `createModifySvJob` as a `Boolean`, which that method has always accepted.
- Its switch also gets the `default` branch it never had — a missing case left `control` null and blew up in `createSaveKeyListener`.
- `ModelView` gets the third menu item, `Messages`/both locale files and `MessagesUtil` the label (`Boolean` / `Wahrheitswert`).

## Build script

`.\build.ps1 -- -Dtest=Foo`, the form `README.md` and `CLAUDE.md` document, aborted with *"No goals have been specified for this build"*: with `PositionalBinding` on, PowerShell binds what follows `--` positionally to `Goals`, so the flag replaced `clean verify` instead of reaching `MavenArgs`. Turning `PositionalBinding` off fixes it; the `-ne '--'` filter that was already there is what the form was written for.

## Tests

`./mvnw clean verify` is green: **335 tests, 0 failures** (303 before).

New: `SingleBooleanValueTest`; an `AInstanzTest` case that every type answers with an empty map on a fresh instanz; a `LoadServiceImplTest` case that loads an instanz json carrying no map at all. Extended: the enum, service, event-chain and messages tests. The `@EnumSource` tests in `SingleValueTypeTest`, `AInstanzTest` and `MessagesUtilTest` are what force a new type to be complete.

## Manual walkthrough in the built product

Ran against `products/tonsias/win32/win32/x86_64/Tonsias.exe` on a fresh workspace, German locale:

- The `CreateInstanzDialog` type combo lists **Text / Ganzzahl / Wahrheitswert** — the new label and the appended ordinal both land correctly.
- Creating the value with `true` typed as text yields a **checked** check box in the Instanz view, i.e. `tryToSetValue` coerced the string.
- Toggling the box turns it green (dirty) exactly like a modified text field, and *Datei → Speichern* writes:
  - `single_value/boolean/2.json` → `{"_connectedInstanzes":["1"],"_ownKey":"2","_value":false}`
  - `instanz/1.json` → `"_singleBooleanKeyValueMap": {"2":"Name"}`
- Restarting on the same workspace restores the unchecked box.

Two findings from that run, both **outside this change**, filed separately:

- #47 — `InstanzView.singlevalueDeltaEventListener` throws an `InjectionException`/NPE when a single-value delta arrives while the Instanz view has nothing selected. Type-independent, predates this branch (`9c5be1f`).
- #48 — the built product exits silently when no JVM is on the PATH, because `tonsias.product` writes no `-vm` into `Tonsias.ini`.

The Delta view stayed empty in the run, but it was opened after the deltas of interest and the log had been reset by an earlier save, so that is inconclusive rather than a regression — those bundles reference `SingleValueType` nowhere. No issue filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
