### PR TITLE
fix: NPE bei Single-Value-Deltas ohne Auswahl (#47)

### DIFF
--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/part/InstanzViewLogicTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/part/InstanzViewLogicTest.java
@@ -2,6 +2,7 @@ package de.tonsias.basis.logic.test.part;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -10,7 +11,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -25,9 +28,12 @@ import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.Instanz;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.intf.non.service.EventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.SingleValueEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.SingleValueNewEvent;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
@@ -100,5 +106,58 @@ public class InstanzViewLogicTest {
 
 		verify(broker).send(InstanzEventConstants.SELECTED,
 				Map.of(IEventBroker.DATA, new InstanzEvent("key", null)));
+	}
+
+	/**
+	 * While nothing is selected there is no key to compare the delta against, so the
+	 * single value is not even resolved.
+	 */
+	@Test
+	void testAffectsShownInstanz_noInstanzShown() {
+		var svService = mock(ISingleValueService.class);
+		var logic = new InstanzViewLogic(null, svService);
+
+		assertThat(logic.affectsShownInstanz(null, DELTA), is(false));
+		verifyNoInteractions(svService);
+	}
+
+	/** A delta of a value the shown instanz owns has to refresh the view. */
+	@Test
+	void testAffectsShownInstanz_connectedValue() {
+		var value = mock(SingleStringValue.class);
+		when(value.getConnectedInstanzKeys()).thenReturn(List.of("shown"));
+
+		assertThat(logicResolving(value).affectsShownInstanz(shownInstanz(), DELTA), is(true));
+	}
+
+	/** A delta of a value belonging to another instanz must not refresh the view. */
+	@Test
+	void testAffectsShownInstanz_foreignValue() {
+		var value = mock(SingleStringValue.class);
+		when(value.getConnectedInstanzKeys()).thenReturn(List.of("other"));
+
+		assertThat(logicResolving(value).affectsShownInstanz(shownInstanz(), DELTA), is(false));
+	}
+
+	/** A deleted value no longer resolves — nothing to refresh for. */
+	@Test
+	void testAffectsShownInstanz_unresolvableValue() {
+		assertThat(logicResolving(null).affectsShownInstanz(mock(Instanz.class), DELTA), is(false));
+	}
+
+	private static final SingleValueEvent DELTA = new SingleValueNewEvent(SingleValueType.SINGLE_STRING, "value",
+			"name", List.of("shown"));
+
+	private Instanz shownInstanz() {
+		var instanz = mock(Instanz.class);
+		when(instanz.getOwnKey()).thenReturn("shown");
+		return instanz;
+	}
+
+	private InstanzViewLogic logicResolving(SingleStringValue value) {
+		var svService = mock(ISingleValueService.class);
+		when(svService.<SingleStringValue>resolveKey(eq(SingleValueType.SINGLE_STRING.getPath()), eq("value"), any()))
+				.thenReturn(Optional.ofNullable(value));
+		return new InstanzViewLogic(null, svService);
 	}
 }

--- a/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzViewLogic.java
+++ b/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzViewLogic.java
@@ -20,6 +20,7 @@ import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.intf.non.service.EventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
+import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants.SingleValueEvent;
 
 public class InstanzViewLogic {
 
@@ -139,6 +140,22 @@ public class InstanzViewLogic {
 			broker.send(InstanzEventConstants.SELECTED, Map.of(IEventBroker.DATA, data));
 			return;
 		}
+	}
+
+	/**
+	 * Whether a single value delta concerns the instanz currently shown. As long as
+	 * nothing is selected there is no key to compare against, so no delta concerns
+	 * the view.
+	 */
+	public boolean affectsShownInstanz(IInstanz shownInstanz, SingleValueEvent event) {
+		if (shownInstanz == null) {
+			return false;
+		}
+
+		SingleValueType type = event.getType();
+		return _svService.resolveKey(type.getPath(), event.getKey(), type.getClazz())//
+				.map(sv -> sv.getConnectedInstanzKeys().contains(shownInstanz.getOwnKey()))//
+				.orElse(false);
 	}
 
 	private void addConsumerOperation(IEventBrokerBridge broker, String openOperation, Consumer<Job> consumer) {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
@@ -369,11 +369,9 @@ public class InstanzView {
 	@Inject
 	@org.eclipse.e4.core.di.annotations.Optional
 	private void singlevalueDeltaEventListener(@UIEventTopic(SingleValueEventConstants.ALL_DELTA_TOPIC) SingleValueEventConstants.SingleValueEvent event) {
-		_singleService.resolveKey(event.getType().getPath(), event.getKey(), event.getType().getClazz()).ifPresent(sv -> {
-			if(sv.getConnectedInstanzKeys().contains(_shownInstanz.getOwnKey())) {
-				updateView();
-			}
-		});
+		if (_logic.affectsShownInstanz(_shownInstanz, event)) {
+			updateView();
+		}
 	}
 	
 	


### PR DESCRIPTION
Behebt #47.

`InstanzView.singlevalueDeltaEventListener` griff im `ifPresent`-Lambda direkt auf
`_shownInstanz.getOwnKey()` zu. Solange in der Eigenschaftsansicht noch nichts
ausgewählt war, endete damit jedes `singleValue/delta/*`-Ereignis als
`InjectionException` mit einem `Internal Error`-Dialog — etwa beim Anlegen einer
neuen Instanz mit Einzelwerten direkt nach dem Start.

## Änderung

Die Entscheidung „betrifft dieses Delta die gezeigte Instanz?" wandert nach
`InstanzViewLogic.affectsShownInstanz(IInstanz, SingleValueEvent)`. Dort ist sie
ohne SWT testbar, und sie liefert `false`, solange nichts ausgewählt ist — der
Einzelwert wird dann gar nicht erst aufgelöst. Der Listener in `InstanzView`
schrumpft auf den Aufruf plus `updateView()` und verhält sich damit wie seine
Nachbarn, die alle an dieser Stelle auf `null` prüfen.

## Tests

Vier neue Fälle in `InstanzViewLogicTest`: keine Auswahl, Wert der gezeigten
Instanz, Wert einer fremden Instanz, nicht mehr auflösbarer Wert.

`.\build.ps1` läuft grün durch — 339 Tests, keine Fehler, Produkt wird gebaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)