### PR TITLE
fix: JRE ins Produkt bündeln (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Only `win32/win32/x86_64` is built; add `<environment>`s to `target-platform-con
 
 - **Target platform**: `target-platform/target-platform.target` — Eclipse SDK 4.36 (2025-06) + Maven-sourced Guava 33.1.0, Gson 2.10.1, JUnit Jupiter 5.14.4, Mockito 5.23.0. It is the single source of truth for **both** the IDE and the Tycho build (consumed as an `eclipse-target-definition` module), so edit it rather than the poms when changing dependencies. Set it as the active target platform in the IDE before anything resolves.
 - **Run the app**: launch `de.tonsias.basis.product/tonsias.product` (E4Application, `-clearPersistedState`). Note `autoStart` config for `org.apache.felix.scr` and `org.eclipse.equinox.event` — DS and the event admin must be running or none of the services resolve. The Tycho test runtime configures the same two bundles for the same reason.
-- **Tests** are JUnit 5, and all three bundles need an OSGi runtime — run them as an **Eclipse JUnit Plug-in Test** in the IDE, or via `./mvnw verify`. What differs is how they obtain their subject:
+- **Tests** are JUnit 5, and every test bundle needs an OSGi runtime — run them as an **Eclipse JUnit Plug-in Test** in the IDE, or via `./mvnw verify`. What differs is how they obtain their subject:
   - Most tests construct it directly or with `@InjectMocks` and need nothing further.
   - Tests that resolve real services through `OsgiUtil.getService(...)` (`InstanzServiceImplTest`, `SingleValueServiceImplTest`, `OsgiUtilTest`) must first call **`E4ServiceContext.prime()`** in `@BeforeEach`. `IEventBrokerBridge` and `IDeltaService` are not plain DS components — they come from `IContextFunction`s that only run when an `IEclipseContext` is asked for their key, and `ChangePropagationListener` is contributed as an e4 _addon_ in `Application.e4xmi`. In the product the workbench triggers all three; headless nothing does, so without priming `InstanzServiceImpl`'s mandatory `@Reference IEventBrokerBridge` stays unsatisfied and the component never activates. Add `prime()` to any new test that touches real services.
   - Those tests also need a **root instanz** (`_inse.getRoot()`), which `ModelView` creates at start-up in the product but nothing creates in a fresh test workspace. They write real files to the instance location (`target/work/data`), which is cleaned per run.
@@ -153,7 +153,7 @@ Every feature follows this sequence end to end:
 
 Never commit directly to `main`.
 
-Step 5 is `.\build.ps1` (or `./mvnw clean verify`). The suite is **green on `main`** — 303 tests across the six test bundles, all passing — so any failure is yours. Never "fix" one by weakening an assertion; if a test looks wrong, check it against the production code first (several once verified `post(..)` where the code had moved to `send(..)`).
+Step 5 is `.\build.ps1` (or `./mvnw clean verify`). The suite is **green on `main`** — every test in every bundle passes — so any failure is yours. Never "fix" one by weakening an assertion; if a test looks wrong, check it against the production code first (several once verified `post(..)` where the code had moved to `send(..)`).
 
 Step 6 places tests in the test bundle matching the layer under test. All run inside OSGi; prefer `OsgiUtil.getService(...)`, which only resolves under a running e4 context, over `@InjectMocks` direct construction. A new bundle's internals need `x-friends` on its `Export-Package` before its test bundle can see them.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,16 @@ JDK 24 is the bundles' highest BREE and the resolution EE the target platform is
 | Path under `de.tonsias.basis.product/target`      | What it is                                        |
 | ------------------------------------------------- | ------------------------------------------------- |
 | `products/tonsias/win32/win32/x86_64/Tonsias.exe` | the launcher — run this to start the built app    |
+| `products/tonsias/win32/win32/x86_64/jre`         | the bundled Java runtime, built by `jlink`        |
 | `products/tonsias-win32.win32.x86_64.zip`         | the same directory zipped, the distributable      |
 | `de.tonsias.basis.product-<version>.zip`          | the p2 repository, for installing/updating via p2 |
 
-Only `win32/win32/x86_64` is built; add `<environment>`s to `target-platform-configuration` in the parent pom to cross-build others.
+The product declares no `<vm>`, so nothing writes a `-vm` into `Tonsias.ini` and the native launcher has to find a JVM itself: `-vm` argument, `-vm` in the ini, a `jre` directory next to the launcher, then the `PATH`. On a machine without `java` on the `PATH` — the normal case here — it used to fail at step four *silently*: exit code 1, no output, no workspace. A `maven-antrun-plugin` execution in `de.tonsias.basis.product/pom.xml` therefore runs `jlink` into that `jre` directory, which makes the installation self-contained and stops the search at step three. Two things follow from it:
+
+- The module list is a property, `tonsias.jre.modules`: `java.se` plus every non-tool `jdk.*` module. Equinox derives the packages of the system bundle from the modules actually in the image, so leaving one out is the same as removing a package — without `jdk.xml.dom` there is no `org.w3c.dom.css` and `org.eclipse.e4.ui.css.swt` does not resolve.
+- `jlink` has to run after `materialize-products` and before `archive-products`, so it sits at `pre-integration-test` and `archive-products` moved off its default phase to `verify`. `mvn package` alone now leaves the product unarchived; `verify` (what `build.ps1` and CI run) is unaffected.
+
+Only `win32/win32/x86_64` is built; add `<environment>`s to `target-platform-configuration` in the parent pom to cross-build others — each one needs its own `jlink` run from a JDK for that platform.
 
 `.github/workflows/build.yml` is the only workflow: it runs the same `./mvnw clean verify` on `windows-latest` for every push and PR to `main`, and it must stay on a Windows runner as long as the target platform declares only the win32 environment. Three things about it are deliberate:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ and revocable until it is saved.
 
 - A headless **Tycho** build mirrors the IDE: `.\build.ps1` compiles every bundle, runs
   every test bundle inside a real Equinox, and materialises the runnable product.
-- **282 tests** across five test bundles cover the model, the JSON persistence, the
-  services, the view logic and the complete event chain. All of them run inside OSGi.
+- The test bundles cover the model, the JSON persistence, the services, the view logic
+  and the complete event chain. All of them run inside OSGi.
 - GitHub Actions builds every push and pull request on Windows and posts the per-bundle
   test results as a single, edited-in-place pull request comment.
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ and revocable until it is saved.
    [0.1.0 release](https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.1.0).
 2. Unzip it anywhere and start `Tonsias.exe`.
 
-The launcher does not bundle a JVM: **Java 24 or newer must be on the `PATH`**, because
-`JavaSE-24` is the highest execution environment the bundles declare. The model is
-written to the application's instance location — the path is shown in
+From 0.2.0 on the zip is self-contained: it carries its own Java runtime in `jre/`
+next to the launcher, so **nothing has to be installed** and the launcher finds a VM
+without a `-vm` argument. The 0.1.0 zip does not — it needs Java 24 or newer on the
+`PATH`, or an explicit `Tonsias.exe -vm <jdk>\bin\javaw.exe`, and starts silently into
+nothing without either.
+
+The model is written to the application's instance location — the path is shown in
 `Window > Preferences` and can be pointed elsewhere with `-data <directory>`.
 
 `de.tonsias.basis.product-0.1.0.zip` in the same release is the p2 repository, for
@@ -106,11 +110,19 @@ The build produces, under `de.tonsias.basis.product/target`:
 | Path                                              | What it is                       |
 | ------------------------------------------------- | -------------------------------- |
 | `products/tonsias/win32/win32/x86_64/Tonsias.exe` | the launcher — run this          |
+| `products/tonsias/win32/win32/x86_64/jre`         | the bundled Java runtime         |
 | `products/tonsias-win32.win32.x86_64.zip`         | the distributable                |
 | `de.tonsias.basis.product-<version>.zip`          | the p2 repository                |
 
+`jre` is built by `jlink` from the JDK that runs the build and makes the installation
+independent of the machine it lands on — the launcher searches for a VM there when no
+`-vm` is given. It is what makes the zip 76 MB rather than 8. Because the runtime has to
+be in place before the zip is written, `archive-products` runs at `verify` rather than at
+`package`; `mvn package` alone therefore leaves the product unarchived.
+
 Only `win32/win32/x86_64` is built; add `<environment>`s to
-`target-platform-configuration` in the parent `pom.xml` for other platforms.
+`target-platform-configuration` in the parent `pom.xml` for other platforms — each needs
+its own `jlink` run, from a JDK for that platform.
 
 ## Developing in the Eclipse IDE
 

--- a/de.tonsias.basis.product/pom.xml
+++ b/de.tonsias.basis.product/pom.xml
@@ -15,6 +15,26 @@
 	<version>0.2.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
+	<properties>
+		<!--
+			The materialized product for the single environment the target
+			platform declares. Add a jlink run per environment here when more
+			<environment>s are added to the parent pom.
+		-->
+		<tonsias.product.dir>${project.build.directory}/products/tonsias/win32/win32/x86_64</tonsias.product.dir>
+		<!--
+			java.se plus every non-tool jdk.* module - the set a JRE image
+			traditionally contained. Equinox derives the packages the system
+			bundle exports from the modules actually in the image, so a module
+			left out here is a package the bundles cannot import: without
+			jdk.xml.dom, for instance, org.w3c.dom.css is missing and
+			org.eclipse.e4.ui.css.swt does not resolve. Only the development
+			tools (jdk.compiler, jdk.jlink, jdk.jshell, ...) are left out, which
+			no bundle imports.
+		-->
+		<tonsias.jre.modules>java.se,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs</tonsias.jre.modules>
+	</properties>
+
 	<build>
 		<plugins>
 			<!--
@@ -35,8 +55,15 @@
 							<goal>materialize-products</goal>
 						</goals>
 					</execution>
+					<!--
+						Off its default phase (package) so that the jlink run
+						below, which is bound in between, ends up inside the
+						zip. The whole product therefore only exists from
+						"verify" on - "mvn package" leaves it unarchived.
+					-->
 					<execution>
 						<id>archive-products</id>
+						<phase>verify</phase>
 						<goals>
 							<goal>archive-products</goal>
 						</goals>
@@ -49,6 +76,62 @@
 						<macosx>tar.gz</macosx>
 					</formats>
 				</configuration>
+			</plugin>
+
+			<!--
+				The product declares no <vm>, so no -vm reaches the Tonsias.ini
+				and the native launcher has to find a JVM itself. Its search
+				order is: -vm argument, -vm in the ini, a "jre" directory next
+				to the launcher, then the PATH. On a machine without java on
+				the PATH the launcher used to give up silently - exit code 1,
+				no output, no workspace.
+
+				jlink builds that "jre" directory straight into the materialized
+				product, which makes the installation self-contained and the
+				launcher find its VM at step three. It runs after
+				materialize-products (package) and before archive-products
+				(verify), so the runtime is part of the distributable.
+			-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>bundle-jre</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<condition property="tonsias.jlink" value="${java.home}/bin/jlink.exe"
+									else="${java.home}/bin/jlink">
+									<os family="windows" />
+								</condition>
+								<!-- jlink refuses to write into an existing directory. -->
+								<delete dir="${tonsias.product.dir}/jre" />
+								<exec executable="${tonsias.jlink}" failonerror="true">
+									<arg value="--add-modules" />
+									<arg value="${tonsias.jre.modules}" />
+									<!--
+										Debug info stays in on purpose:
+										stripping it costs the JDK frames of
+										every stack trace their line numbers,
+										and the .log of the running application
+										is where bug reports come from.
+									-->
+									<arg value="--no-header-files" />
+									<arg value="--no-man-pages" />
+									<arg value="--compress" />
+									<arg value="zip-6" />
+									<arg value="--output" />
+									<arg value="${tonsias.product.dir}/jre" />
+								</exec>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Behebt #48.

`tonsias.product` hat einen leeren `<vm>`-Abschnitt, also schreibt Tycho kein `-vm`
in die `Tonsias.ini`. Der native Launcher sucht sich die JVM dann selbst — `-vm`-
Argument, `-vm` in der ini, ein `jre`-Verzeichnis neben dem Launcher, dann der `PATH`.
Ohne `java` im `PATH` gingen ihm auf Stufe vier die Möglichkeiten aus, und zwar
kommentarlos: Exit-Code 1, keine Ausgabe, kein Log, kein Workspace.

## Änderung

`jlink` baut dieses `jre`-Verzeichnis jetzt direkt in das materialisierte Produkt.
Die Installation bringt ihre eigene Laufzeit mit, die Suche endet auf Stufe drei, und
das gebaute Produkt läuft auf jeder Maschine ohne Java-Installation.

Zwei Details, die im Code kommentiert sind:

- **Modulliste** (`tonsias.jre.modules`): `java.se` plus jedes `jdk.*`-Modul, das kein
  Entwicklungswerkzeug ist — der Satz, den ein JRE-Image traditionell enthielt. Equinox
  leitet die Pakete des System-Bundles aus den tatsächlich im Image vorhandenen Modulen
  ab, ein weggelassenes Modul ist also ein fehlendes Paket. Mit einer knapperen Liste
  ohne `jdk.xml.dom` fehlte `org.w3c.dom.css`, und `org.eclipse.e4.ui.css.swt` ließ sich
  nicht auflösen.
- **Phasen**: Der Schritt muss zwischen `materialize-products` und `archive-products`
  liegen, damit die Laufzeit im Zip landet. Er hängt an `pre-integration-test`, und
  `archive-products` wandert von seiner Standardphase auf `verify`. `build.ps1` und CI
  rufen `verify` auf und merken davon nichts; ein reines `mvn package` lässt das Produkt
  jetzt unarchiviert.

`--strip-debug` ist bewusst nicht gesetzt: es kostet die JDK-Frames jedes Stacktraces
ihre Zeilennummern, und das `.log` der laufenden Anwendung ist die einzige Quelle für
Fehlerberichte.

## Verifikation

`.\build.ps1` läuft grün durch — 335 Tests, keine Fehler.

Das gebaute Produkt gestartet auf genau der Maschine aus dem Issue (`JAVA_HOME` leer,
kein `java` im `PATH`), ohne `-vm`:

```
PS> .\Tonsiasc.exe -data <ws> -consoleLog
!SESSION 2026-08-08 09:29:04.718 ------------------------------------------------
java.version=24.0.1
BootLoader constants: OS=win32, ARCH=x86_64, WS=win32, NL=de_DE
```

Fenster kommt hoch, `.metadata` und die Wurzel-Instanz `instanz/0.json` werden
angelegt — dasselbe Verhalten wie zuvor nur mit explizitem
`-vm C:\dev\java\jdk-24.0.1\bin\javaw.exe`, und keine Resolver-Fehler im Log.

## Kosten

Die Laufzeit ist 68 MB, das Distributions-Zip wächst von ~8 MB auf 76 MB. Die
p2-Repository-Zip bleibt unverändert — die Laufzeit hängt am materialisierten Produkt,
nicht am Feature.

README.md und CLAUDE.md sind entsprechend nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Nachtrag:** In `README.md` und `CLAUDE.md` sind außerdem die Angaben zur Anzahl der
Tests entfallen — eine Zahl, die bei jedem neuen Test nachgezogen werden müsste, sagt
nichts aus, weil ohnehin alle Tests laufen müssen. Dasselbe für die Anzahl der
Test-Bundles, die in `CLAUDE.md` noch bei „three" stand.
