### PR TITLE
fix: eine geteilte Instanz aus den ContextFunctions (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ delta.view.*         the Delta view feature: logic / ui (fragment.e4xmi) / ui.te
 **Dependency injection — three mechanisms coexist.**
 
 1. **DS `@Component` + `@Reference`** for the plain services. Components are declared by **hand-maintained XML in `OSGI-INF/` referenced from `Service-Component:`** — adding one means both edits. (`de.tonsias.basis.osgi/META-INF/MANIFEST.MF` still lists two `…osgi.util.*.xml` files that do not exist.)
-2. **`ContextFunction`** for services needing the e4 context (`EventBrokerContextFunction`, `DeltaServiceContextFunction`). Note they build a **new** instance per `compute(..)` — see issue #52.
+2. **`ContextFunction`** for services needing the e4 context (`EventBrokerContextFunction`, `DeltaServiceContextFunction`). Both extend `SharedInstanceContextFunction`, which builds the instance once out of the bundle's own service context and answers every later `compute(..)` out of the service registry — an e4 context caches per *asking* context, so a per-call instance would give every part its own delta log.
 3. **`OsgiUtil.lazyLoading(Class, Consumer)`** for code constructed before OSGi is ready (`ChangePropagationListener`).
 
 **UI.** e4 model-first; parts are POJOs with `@PostConstruct postConstruct(Composite parent)` and `@Inject` fields. Non-trivial behaviour belongs in a `*.logic` bundle so it is testable without SWT — keep that split. Views react through `@UIEventTopic`/`@EventTopic` rather than polling.

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ContextFunctionSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ContextFunctionSystemTest.java
@@ -1,0 +1,166 @@
+package de.tonsias.basis.osgi.test.system;
+
+import static de.tonsias.basis.osgi.test.ProductRuntime.ROOT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.test.ProductRuntime;
+import de.tonsias.basis.osgi.util.OsgiUtil;
+
+/**
+ * What the two {@code IContextFunction}s hand out, asked the way the workbench
+ * asks.
+ * <p>
+ * An {@code IEclipseContext} caches a context function's result per asking
+ * context, and every part gets a context of its own - so a function is asked
+ * once per part, not once per application. What comes back has to be the
+ * instance the service registry holds, or a part would work on a delta log of
+ * its own: it would render changes it happened to be present for, and a save on
+ * one log would leave the other standing.
+ * </p>
+ *
+ * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/52">#52</a>
+ */
+public class ContextFunctionSystemTest {
+
+	IEclipseContext _serviceContext;
+
+	final List<IEclipseContext> _partContexts = new ArrayList<>();
+
+	IInstanzService _inse;
+
+	@BeforeEach
+	void beforeEach() {
+		ProductRuntime.start();
+		_inse = ProductRuntime.instanzService();
+		_serviceContext = EclipseContextFactory.getServiceContext(bundleContext());
+		ProductRuntime.flushDeltas();
+	}
+
+	@AfterEach
+	void afterEach() {
+		_partContexts.forEach(IEclipseContext::dispose);
+		_partContexts.clear();
+		ProductRuntime.flushDeltas();
+	}
+
+	private static BundleContext bundleContext() {
+		return FrameworkUtil.getBundle(ContextFunctionSystemTest.class).getBundleContext();
+	}
+
+	/** a context of the kind e4 creates for a part, and asks the injection from */
+	private IEclipseContext partContext(String name) {
+		IEclipseContext partContext = _serviceContext.createChild(name);
+		_partContexts.add(partContext);
+		return partContext;
+	}
+
+	private <T> T injectedInto(IEclipseContext context, Class<T> type) {
+		return type.cast(context.get(type.getName()));
+	}
+
+	private int registrationsOf(Class<?> type) throws InvalidSyntaxException {
+		return bundleContext().getServiceReferences(type, null).size();
+	}
+
+	@Test
+	void testDeltaService_aPartContextIsGivenTheRegisteredInstance() {
+		IDeltaService fromPart = injectedInto(partContext("DeltaView"), IDeltaService.class);
+
+		assertThat(fromPart, is(notNullValue()));
+		assertThat(fromPart, is(sameInstance(OsgiUtil.getService(IDeltaService.class))));
+	}
+
+	@Test
+	void testEventBrokerBridge_aPartContextIsGivenTheRegisteredInstance() {
+		IEventBrokerBridge fromPart = injectedInto(partContext("InstanzView"), IEventBrokerBridge.class);
+
+		assertThat(fromPart, is(notNullValue()));
+		assertThat(fromPart, is(sameInstance(OsgiUtil.getService(IEventBrokerBridge.class))));
+	}
+
+	@Test
+	void testDeltaService_twoPartContextsShareOneInstance() {
+		IDeltaService first = injectedInto(partContext("first"), IDeltaService.class);
+		IDeltaService second = injectedInto(partContext("second"), IDeltaService.class);
+
+		assertThat(first, is(sameInstance(second)));
+	}
+
+	/**
+	 * Asking is what runs the function, so asking often used to register often -
+	 * and nothing ever unregistered those instances again.
+	 */
+	@Test
+	void testCompute_askingFromSeveralContextsRegistersTheServiceOnlyOnce() throws InvalidSyntaxException {
+		injectedInto(partContext("first"), IDeltaService.class);
+		injectedInto(partContext("second"), IDeltaService.class);
+		injectedInto(partContext("third"), IEventBrokerBridge.class);
+
+		assertThat(registrationsOf(IDeltaService.class), is(1));
+		assertThat(registrationsOf(IEventBrokerBridge.class), is(1));
+	}
+
+	/**
+	 * The point of it all: a part that opens after the fact sees the changes that
+	 * happened before it, because there is only ever the one log.
+	 */
+	@Test
+	void testDeltaService_aPartOpenedAfterAChangeSeesIt() {
+		_inse.createInstanz(ROOT, Type.SEND);
+
+		IDeltaService openedAfterwards = injectedInto(partContext("late"), IDeltaService.class);
+
+		assertThat(openedAfterwards.getDeltas(), hasSize(3));
+	}
+
+	/** And the other way round: a save on the shared log empties it for everyone. */
+	@Test
+	void testDeltaService_aSaveThroughOneContextEmptiesTheLogForTheOther() {
+		IDeltaService fromPart = injectedInto(partContext("part"), IDeltaService.class);
+		_inse.createInstanz(ROOT, Type.SEND);
+
+		ProductRuntime.deltaService().saveDeltas();
+
+		assertThat(fromPart.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	/**
+	 * A part context dies with its part, and disposing a context un-injects
+	 * everything that was made from it. The shared instance must not be one of
+	 * those, or closing a view would leave the registry handing out a service whose
+	 * fields are null.
+	 */
+	@Test
+	void testCompute_theSharedInstanceOutlivesTheContextThatAskedForIt() {
+		IEclipseContext partContext = partContext("closed again");
+		injectedInto(partContext, IEventBrokerBridge.class);
+		injectedInto(partContext, IDeltaService.class);
+
+		partContext.dispose();
+		_partContexts.remove(partContext);
+
+		assertThat(ProductRuntime.broker().send("de/tonsias/test/afterDispose", null), is(true));
+		assertThat(ProductRuntime.deltaService().getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
@@ -1,29 +1,31 @@
 package de.tonsias.basis.osgi.util;
 
-import org.eclipse.e4.core.contexts.ContextFunction;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IContextFunction;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 
 import de.tonsias.basis.osgi.impl.DeltaServiceImpl;
 import de.tonsias.basis.osgi.intf.IDeltaService;
 
+/**
+ * There is exactly one delta log in the application, see
+ * {@link SharedInstanceContextFunction} - the Delta view renders the same log
+ * that the save handler writes out.
+ */
 @Component(service = IContextFunction.class, //
 		property = "service.context.key=de.tonsias.basis.osgi.intf.IDeltaService")
-public class DeltaServiceContextFunction extends ContextFunction {
+public class DeltaServiceContextFunction extends SharedInstanceContextFunction<IDeltaService> {
+
+	public DeltaServiceContextFunction() {
+		super(IDeltaService.class);
+	}
 
 	@Override
-	public Object compute(IEclipseContext context) {
-		var deltaServiceImpl = ContextInjectionFactory.make(DeltaServiceImpl.class, context);
-		deltaServiceImpl.postConstruct();
-
-		BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
-		bundleContext.registerService(IDeltaService.class, deltaServiceImpl, null);
-
-		return deltaServiceImpl;
+	protected IDeltaService create(IEclipseContext context) {
+		DeltaServiceImpl deltaService = ContextInjectionFactory.make(DeltaServiceImpl.class, context);
+		deltaService.postConstruct();
+		return deltaService;
 	}
 
 }

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
@@ -23,6 +23,10 @@ public class DeltaServiceContextFunction extends SharedInstanceContextFunction<I
 
 	@Override
 	protected IDeltaService create(IEclipseContext context) {
+		// the impl also injects IInstanzService and ISingleValueService, and those only
+		// activate once the bridge is registered - which happens while its own field is
+		// injected. That the bridge comes first is the field order and nothing else,
+		// see https://github.com/Tobias-Bonsack/Tonsias/issues/56
 		DeltaServiceImpl deltaService = ContextInjectionFactory.make(DeltaServiceImpl.class, context);
 		deltaService.postConstruct();
 		return deltaService;

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/EventBrokerContextFunction.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/EventBrokerContextFunction.java
@@ -1,27 +1,29 @@
 package de.tonsias.basis.osgi.util;
 
-import org.eclipse.e4.core.contexts.ContextFunction;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IContextFunction;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 
 import de.tonsias.basis.osgi.impl.EventBrokerBridgeImpl;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 
+/**
+ * There is exactly one bridge, see {@link SharedInstanceContextFunction} - the
+ * services take theirs from the registry, the parts get theirs injected, and
+ * {@link IEventBrokerBridge#unSubscribe(org.osgi.service.event.EventHandler)}
+ * only reaches a handler that was subscribed through the same instance.
+ */
 @Component(service = IContextFunction.class, //
 		property = "service.context.key=de.tonsias.basis.osgi.intf.IEventBrokerBridge")
-public class EventBrokerContextFunction extends ContextFunction {
+public class EventBrokerContextFunction extends SharedInstanceContextFunction<IEventBrokerBridge> {
+
+	public EventBrokerContextFunction() {
+		super(IEventBrokerBridge.class);
+	}
 
 	@Override
-	public Object compute(IEclipseContext context) {
-		var eventBrokerBridge = ContextInjectionFactory.make(EventBrokerBridgeImpl.class, context);
-
-		BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
-		bundleContext.registerService(IEventBrokerBridge.class, eventBrokerBridge, null);
-
-		return eventBrokerBridge;
+	protected IEventBrokerBridge create(IEclipseContext context) {
+		return ContextInjectionFactory.make(EventBrokerBridgeImpl.class, context);
 	}
 }

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/SharedInstanceContextFunction.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/SharedInstanceContextFunction.java
@@ -1,0 +1,60 @@
+package de.tonsias.basis.osgi.util;
+
+import org.eclipse.e4.core.contexts.ContextFunction;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * A context function that hands every asking context the same instance.
+ * <p>
+ * An {@link IEclipseContext} caches what a context function computes per
+ * <em>asking</em> context, and every part context asks on its own. A function
+ * that builds something new on each call therefore hands out one instance per
+ * part - for a service that carries state, such as the delta log, that means
+ * several logs, each holding a different part of the picture, and a save on one
+ * of them leaving the others untouched. The instance is built once and put into
+ * the service registry, every later call is answered out of the registry, so
+ * {@code @Inject} and {@link OsgiUtil#getService(Class)} arrive at the same
+ * object.
+ * </p>
+ * <p>
+ * It is built out of this bundle's service context and never out of the context
+ * that happened to ask first: a part context is disposed with its part, and
+ * disposing a context un-injects everything made from it. The shared instance
+ * would be left with null fields while the registry keeps handing it out.
+ * </p>
+ *
+ * @param <T> the service interface the instance is registered under
+ */
+abstract class SharedInstanceContextFunction<T> extends ContextFunction {
+
+	private final Class<T> _serviceClass;
+
+	protected SharedInstanceContextFunction(Class<T> serviceClass) {
+		_serviceClass = serviceClass;
+	}
+
+	@Override
+	public final synchronized Object compute(IEclipseContext context) {
+		BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
+
+		T shared = OsgiUtil.getService(_serviceClass, bundleContext);
+		if (shared == null) {
+			shared = create(EclipseContextFactory.getServiceContext(bundleContext));
+			bundleContext.registerService(_serviceClass, shared, null);
+		}
+		return shared;
+	}
+
+	/**
+	 * Builds the one instance. Called at most once per framework run, with the
+	 * lookup already having come up empty.
+	 *
+	 * @param context this bundle's service context - the instance is injected out
+	 *                of it and lives as long as it does, not as long as whoever
+	 *                asked first
+	 */
+	protected abstract T create(IEclipseContext context);
+}

--- a/de.tonsias.delta.view.ui.test/src/de/tonsias/delta/view/ui/test/system/DeltaViewSystemTest.java
+++ b/de.tonsias.delta.view.ui.test/src/de/tonsias/delta/view/ui/test/system/DeltaViewSystemTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
@@ -44,18 +45,13 @@ import de.tonsias.delta.view.ui.tree.EventTreeNodeWrapper;
  * as the model changes underneath it.
  * </p>
  * <p>
- * <b>One thing this exposed and now pins down:</b>
- * {@code DeltaServiceContextFunction} builds a <em>new</em>
- * {@code DeltaServiceImpl} on every compute, and an e4 context caches a
- * function's result per asking context. A part context is its own asking
- * context, so the view does not render the instance
- * {@code OsgiUtil.getService(IDeltaService.class)} hands out - it renders one of
- * its own. The two stay in step only because both subscribe to the same topics
- * and both clear on {@code SAVE_ALL}. The tests below therefore open the view
- * first and change the model afterwards, which is also the order the product
- * runs in. See
- * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/52">#52</a>; once
- * that is fixed the view can be opened on an already filled log again.
+ * What is injected is the one registered {@link IDeltaService}, whichever
+ * context asks - so the view renders the same log the save handler writes out,
+ * whether it was opened before or after the changes. That the context function
+ * shares its instance rather than building one per part is
+ * {@code ContextFunctionSystemTest}; here it is taken as given and the view is
+ * opened both ways round. See
+ * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/52">#52</a>.
  * </p>
  */
 public class DeltaViewSystemTest {
@@ -168,6 +164,21 @@ public class DeltaViewSystemTest {
 		openView();
 
 		assertThat(treeOf().getItemCount(), is(0));
+	}
+
+	/**
+	 * The injected service is the registered one, not a copy the part context
+	 * computed for itself - a view opened after the fact is therefore already
+	 * showing what happened before it.
+	 */
+	@Test
+	void testPostConstruct_opensOnAnAlreadyFilledLogShowingItsRows() {
+		oneChange();
+
+		openView();
+
+		assertThat(shownLog(), is(sameInstance(ProductRuntime.deltaService())));
+		assertThat(treeOf().getItemCount(), is(2));
 	}
 
 	/**


### PR DESCRIPTION
Behebt #52.

## Problem

`DeltaServiceContextFunction.compute(..)` und `EventBrokerContextFunction.compute(..)` bauten bei jedem Aufruf eine neue Instanz, riefen ihr `postConstruct()` und registrierten sie **zusätzlich** in der Service-Registry. Ein e4-`IEclipseContext` cacht das Ergebnis einer `IContextFunction` pro *fragendem* Context, und jeder Part-Context fragt für sich — also bekam jeder Part sein eigenes Delta-Log, mit eigenen Subscriptions und eigener Vorstellung davon, was noch zu speichern ist. `OsgiUtil.getService(..)` gab dagegen die zuerst registrierte Instanz heraus. Die Registrierungen wurden nie wieder abgemeldet.

Sichtbar wurde das in der Delta-View: erst nach dem Öffnen entstandene Änderungen erschienen, frühere fehlten, und ein `saveDeltas()` auf der einen Instanz ließ das Log der anderen stehen.

## Lösung

Neue gemeinsame Basis `SharedInstanceContextFunction`:

- erst in der Registry nachsehen, nur bei leerem Ergebnis bauen und registrieren — `compute(..)` ist damit idempotent, es gibt genau eine Registrierung;
- gebaut wird aus dem **Service-Context des eigenen Bundles**, nicht aus dem Context, der zufällig zuerst gefragt hat. Ein Part-Context stirbt mit seinem Part, und das Verwerfen eines Contexts un-injiziert alles, was daraus gebaut wurde — die geteilte Instanz hätte danach `null`-Felder, während die Registry sie weiter herausgibt.

## Tests

- `ContextFunctionSystemTest` (neu, 7 Tests): zwei Part-Contexts bekommen dieselbe Instanz wie `OsgiUtil.getService(..)`; mehrfaches Fragen registriert genau einmal; ein spät geöffneter Part sieht die vorherigen Deltas; ein Save über einen Context leert das Log für den anderen; die geteilte Instanz überlebt das Verwerfen des fragenden Contexts.
- `DeltaViewSystemTest`: das Klassen-Javadoc beschrieb bisher das alte Verhalten; die View wird jetzt auch auf ein bereits gefülltes Log geöffnet und zeigt dessen Zeilen (`testPostConstruct_opensOnAnAlreadyFilledLogShowingItsRows`).
- `CLAUDE.md` an das neue Verhalten angepasst.

`.\build.ps1` ist grün (363 Tests, 0 Failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)