### PR TITLE
fix: saveDeltas() bricht nicht mehr ab und setzt sein Log immer zurück (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ delta.view.*         the Delta view feature: logic / ui (fragment.e4xmi) / ui.te
 
 - Topics and payload records live together in `…intf.non.service.*EventConstants`. **Adding a topic means adding its payload record next to it and registering it in `KNOWN_DELTA`.**
 - `ChangePropagationListener` keeps both ends of every relation in sync and re-enters the services with `Type.SEND`, so **a careless new listener can loop**. The services guard by returning `false` without firing when already in the requested state — keep that.
-- `IDeltaService` accumulates every delta since the last save. `saveDeltas()` folds the log into four key sets, calls the services, and resets. `OPEN_OPERATION`/`CLOSE_OPERATION` bracket an operation; `SAVE_ALL` triggers the save; the Delta view renders the log using those brackets.
+- `IDeltaService` accumulates every delta since the last save. `saveDeltas()` folds the log into four key sets, calls the services, and resets — **it resets in a `finally`**, and a failing step is collected as a suppressed exception rather than ending the save, so one bad delete cannot wedge every save that follows. A delete that finds no file counts as done. `OPEN_OPERATION`/`CLOSE_OPERATION` bracket an operation; `SAVE_ALL` triggers the save; the Delta view renders the log using those brackets.
 
 **Dependency injection — three mechanisms coexist.**
 

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/ProductRuntime.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/ProductRuntime.java
@@ -5,17 +5,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.concurrent.CompletionException;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
-import org.osgi.service.event.Event;
 
 import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.model.enums.SingleValueType;
@@ -54,6 +53,9 @@ public final class ProductRuntime {
 	public static final String ROOT = "0";
 
 	public static final String INSTANZ_PATH = "instanz/";
+
+	/** keeps a {@link #block(Path) blocked} directory non-empty */
+	private static final String IN_THE_WAY = "in-the-way.txt";
 
 	private ProductRuntime() {
 	}
@@ -106,20 +108,49 @@ public final class ProductRuntime {
 	 * Writes out whatever is pending and empties the delta log. A test that leaves
 	 * the log filled would otherwise have its events folded into the next test's
 	 * save.
+	 * <p>
+	 * {@code saveDeltas()} empties its log whatever the save ran into, so a test
+	 * that fabricated a delete for something that was never written does not drag
+	 * the rest of the bundle down with it. What it threw is of no interest here -
+	 * the test that cares about it asserts on it itself.
+	 * </p>
 	 */
 	public static void flushDeltas() {
 		try {
 			deltaService().saveDeltas();
 		} catch (CompletionException e) {
-			// A delete of something that was never written makes saveDeltas() give up
-			// before it resets its log - a test that fabricates a delete event lands
-			// here. Left alone, the same failure would repeat on every save that
-			// follows, so the log is put back into its start state by hand. The
-			// application itself has no such rescue, see
-			// https://github.com/Tobias-Bonsack/Tonsias/issues/53
-			Collection<Event> deltas = deltaService().getDeltas();
-			deltas.clear();
-			deltas.add(IDeltaService.START_EVENT);
+			// the log is empty again either way
+		}
+	}
+
+	// ---------- making a delete fail ----------
+
+	/**
+	 * Puts something in the way of {@code path}: a directory with a file in it,
+	 * where the services expect a JSON file. Deleting that fails with
+	 * {@code DirectoryNotEmptyException} however often it is tried - a delete that
+	 * merely finds nothing has reached its goal and is no failure at all, so it is
+	 * no use for testing what a save does when a step of it goes wrong.
+	 * <p>
+	 * Whoever blocks a path {@link #unblock(Path) unblocks} it again, the workspace
+	 * is shared by every test in the bundle.
+	 * </p>
+	 */
+	public static void block(Path path) {
+		try {
+			Files.createDirectories(path);
+			Files.writeString(path.resolve(IN_THE_WAY), "");
+		} catch (IOException e) {
+			throw new AssertionError("could not block " + path, e);
+		}
+	}
+
+	public static void unblock(Path path) {
+		try {
+			Files.deleteIfExists(path.resolve(IN_THE_WAY));
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			throw new AssertionError("could not unblock " + path, e);
 		}
 	}
 

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaPersistenceSystemTest.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
@@ -286,11 +285,7 @@ public class DeltaPersistenceSystemTest {
 	}
 
 	private void flush() {
-		try {
-			_delta.saveDeltas();
-		} catch (CompletionException e) {
-			// an earlier test may have left a delete for a file that was never written
-		}
+		_delta.saveDeltas();
 	}
 
 	private Instanz reloadInstanz(String key) {

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaSaveFailureSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/DeltaSaveFailureSystemTest.java
@@ -1,0 +1,178 @@
+package de.tonsias.basis.osgi.test.system;
+
+import static de.tonsias.basis.osgi.test.ProductRuntime.ROOT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
+import de.tonsias.basis.osgi.test.ProductRuntime;
+
+/**
+ * What a save does when one of its four steps cannot be carried out.
+ * <p>
+ * The log is the only record of what still needs writing, so a save that gives
+ * up halfway and leaves its log standing does not just lose this one write: the
+ * next save folds the same set again, fails on the same step again, and from
+ * then on the application saves nothing at all without ever saying so. Two
+ * things keep that from happening - a delete that finds no file has reached its
+ * goal and is no failure, and whatever else goes wrong, the log is handed back
+ * empty.
+ * </p>
+ *
+ * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/53">#53</a>
+ */
+public class DeltaSaveFailureSystemTest {
+
+	/** no instanz is ever written under this key, it only names a path */
+	private static final String NEVER_WRITTEN = "zzznotwritten";
+
+	IInstanzService _inse;
+
+	ISingleValueService _svs;
+
+	IDeltaService _delta;
+
+	Path _blocked;
+
+	@BeforeEach
+	void beforeEach() {
+		ProductRuntime.start();
+		_inse = ProductRuntime.instanzService();
+		_svs = ProductRuntime.singleValueService();
+		_delta = ProductRuntime.deltaService();
+
+		ProductRuntime.flushDeltas();
+	}
+
+	@AfterEach
+	void afterEach() {
+		if (_blocked != null) {
+			ProductRuntime.unblock(_blocked);
+			_blocked = null;
+		}
+		ProductRuntime.flushDeltas();
+	}
+
+	/** a key whose instanz file cannot be deleted, however often it is tried */
+	private String blockedInstanzKey() {
+		_blocked = ProductRuntime.instanzFile(NEVER_WRITTEN);
+		ProductRuntime.block(_blocked);
+		return NEVER_WRITTEN;
+	}
+
+	// ---------- a delete with nothing to delete ----------
+
+	@Test
+	void testDeleteAll_instanzWithoutAFile_isNoFailure() {
+		assertThat(_inse.deleteAll(Set.of(NEVER_WRITTEN)), is(true));
+	}
+
+	@Test
+	void testDeleteAll_singleValueWithoutAFileInAnyFolder_isNoFailure() {
+		assertThat(_svs.deleteAll(Set.of(NEVER_WRITTEN)), is(true));
+	}
+
+	/**
+	 * The everyday way into it: something is marked for deletion that never made it
+	 * to disk. Before, that alone was enough to wedge every following save.
+	 */
+	@Test
+	void testSaveDeltas_deletingAnInstanzThatWasNeverWritten_savesTheRestAndEmptiesTheLog() {
+		IInstanz kept = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.markInstanzAsDelete(NEVER_WRITTEN, Type.SEND);
+
+		_delta.saveDeltas();
+
+		assertThat(ProductRuntime.instanzFileExists(kept.getOwnKey()), is(true));
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	/**
+	 * The same value deleted twice over two saves - the second delete finds the
+	 * file already gone, which is exactly what it wanted.
+	 */
+	@Test
+	void testSaveDeltas_deletingASingleValueTwice_isNoFailure() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_delta.saveDeltas();
+		_svs.markSingleValueAsDelete(value.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+		assertThat(ProductRuntime.valueFileExists(SingleValueType.SINGLE_STRING, value.getOwnKey()), is(false));
+
+		_svs.markSingleValueAsDelete(value.getOwnKey(), Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	// ---------- a delete that really fails ----------
+
+	/**
+	 * The single values are written after the instanzes are deleted. A failing
+	 * delete used to end the save right there, so a value change made in the same
+	 * operation was silently dropped.
+	 */
+	@Test
+	void testSaveDeltas_afterAFailingDeleteTheRemainingStepsStillRun() {
+		String blocked = blockedInstanzKey();
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		SingleStringValue value = _svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", "content",
+				Type.SEND);
+		_inse.markInstanzAsDelete(blocked, Type.SEND);
+
+		assertThrows(CompletionException.class, () -> _delta.saveDeltas());
+
+		assertThat(ProductRuntime.instanzFileExists(owner.getOwnKey()), is(true));
+		assertThat(ProductRuntime.valueFileExists(SingleValueType.SINGLE_STRING, value.getOwnKey()), is(true));
+	}
+
+	/** What went wrong is not swallowed - it is carried out as suppressed. */
+	@Test
+	void testSaveDeltas_aFailingDeleteIsReportedToTheCaller() {
+		String blocked = blockedInstanzKey();
+		_inse.markInstanzAsDelete(blocked, Type.SEND);
+
+		CompletionException thrown = assertThrows(CompletionException.class, () -> _delta.saveDeltas());
+
+		assertThat(thrown.getSuppressed(), is(arrayWithSize(1)));
+	}
+
+	/**
+	 * And the point of the whole exercise: the failure does not outlive the save it
+	 * happened in. The log is spent, so the next save is about what has happened
+	 * since - not about the same broken delete all over again.
+	 */
+	@Test
+	void testSaveDeltas_aFailingDeleteStillEmptiesTheLog() {
+		String blocked = blockedInstanzKey();
+		_inse.markInstanzAsDelete(blocked, Type.SEND);
+		assertThrows(CompletionException.class, () -> _delta.saveDeltas());
+
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+
+		IInstanz afterwards = _inse.createInstanz(ROOT, Type.SEND);
+		_delta.saveDeltas();
+
+		assertThat(ProductRuntime.instanzFileExists(afterwards.getOwnKey()), is(true));
+		assertThat(_delta.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/InstanzServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/InstanzServiceSystemTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -535,16 +536,39 @@ public class InstanzServiceSystemTest {
 	}
 
 	/**
-	 * A delete that finds no file has to surface rather than pass silently, and one
+	 * No file is the state a delete is after, so finding none is no failure - an
+	 * instanz created and dropped again before any save never had one, and
+	 * {@code saveDeltas} would otherwise fail on it again with every save from then
+	 * on.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/53">#53</a>
+	 */
+	@Test
+	void testDeleteAll_keysWithoutAFileAreNoFailure() {
+		assertThat(_inse.deleteAll(Set.of("no-such-key-1", "no-such-key-2")), is(true));
+	}
+
+	/**
+	 * What does fail still has to surface rather than pass silently, and one
 	 * failure must not hide the others - {@code saveDeltas} hands over a whole set
 	 * at once.
 	 */
 	@Test
 	void testDeleteAll_collectsEveryFailureInOneException() {
-		CompletionException thrown = assertThrows(CompletionException.class,
-				() -> _inse.deleteAll(Set.of("no-such-key-1", "no-such-key-2")));
+		Path firstBlocked = ProductRuntime.instanzFile("blocked-1");
+		Path secondBlocked = ProductRuntime.instanzFile("blocked-2");
+		ProductRuntime.block(firstBlocked);
+		ProductRuntime.block(secondBlocked);
 
-		assertThat(List.of(thrown.getSuppressed()), hasSize(2));
+		try {
+			CompletionException thrown = assertThrows(CompletionException.class,
+					() -> _inse.deleteAll(Set.of("blocked-1", "blocked-2")));
+
+			assertThat(List.of(thrown.getSuppressed()), hasSize(2));
+		} finally {
+			ProductRuntime.unblock(firstBlocked);
+			ProductRuntime.unblock(secondBlocked);
+		}
 	}
 
 	/**

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -383,20 +384,38 @@ public class SingleValueServiceSystemTest {
 		assertThat(ProductRuntime.valueFileExists(SingleValueType.SINGLE_INTEGER, key), is(false));
 	}
 
+	/**
+	 * Coming up empty in every folder is no failure: no file is the state the
+	 * delete is after, and a value created and dropped again before any save never
+	 * had one.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/53">#53</a>
+	 */
 	@Test
-	void testDeleteAll_aValueInNoFolderAtAllFails() {
-		CompletionException thrown = assertThrows(CompletionException.class,
-				() -> _svs.deleteAll(Set.of("no-such-key")));
-
-		assertThat(List.of(thrown.getSuppressed()), hasSize(1));
+	void testDeleteAll_aValueInNoFolderAtAllIsNoFailure() {
+		assertThat(_svs.deleteAll(Set.of("no-such-key")), is(true));
 	}
 
+	/**
+	 * What does fail still has to surface, and one failure must not hide the others
+	 * - {@code saveDeltas} hands over a whole set at once.
+	 */
 	@Test
 	void testDeleteAll_collectsEveryFailureInOneException() {
-		CompletionException thrown = assertThrows(CompletionException.class,
-				() -> _svs.deleteAll(Set.of("no-such-key-1", "no-such-key-2")));
+		Path firstBlocked = ProductRuntime.valueFile(SingleValueType.SINGLE_STRING, "blocked-1");
+		Path secondBlocked = ProductRuntime.valueFile(SingleValueType.SINGLE_STRING, "blocked-2");
+		ProductRuntime.block(firstBlocked);
+		ProductRuntime.block(secondBlocked);
 
-		assertThat(List.of(thrown.getSuppressed()), hasSize(2));
+		try {
+			CompletionException thrown = assertThrows(CompletionException.class,
+					() -> _svs.deleteAll(Set.of("blocked-1", "blocked-2")));
+
+			assertThat(List.of(thrown.getSuppressed()), hasSize(2));
+		} finally {
+			ProductRuntime.unblock(firstBlocked);
+			ProductRuntime.unblock(secondBlocked);
+		}
 	}
 
 	@Test

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/DeltaServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/DeltaServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.osgi.service.event.Event;
@@ -71,13 +72,40 @@ public class DeltaServiceImpl implements IDeltaService {
 			}
 		}
 
-		_instanzService.saveAll(instanzKeysToSave);
-		_instanzService.deleteAll(instanzKeysToDelete);
-		_singleValueService.saveAll(singlevalueKeysToSave);
-		_singleValueService.deleteAll(singlevalueKeysToDelete);
+		// a value that is created and dropped again within one log is in both sets:
+		// it is written first and removed afterwards, so nothing is left behind
+		CompletionException failures = new CompletionException("saving the deltas failed", null);
+		try {
+			attempt(failures, () -> _instanzService.saveAll(instanzKeysToSave));
+			attempt(failures, () -> _instanzService.deleteAll(instanzKeysToDelete));
+			attempt(failures, () -> _singleValueService.saveAll(singlevalueKeysToSave));
+			attempt(failures, () -> _singleValueService.deleteAll(singlevalueKeysToDelete));
+		} finally {
+			// The log is the difference against the disk, and every one of the four steps
+			// was given its chance - so it is spent, whatever came of it. Keeping it would
+			// fold the same set again on the next save, fail on the same step again, and
+			// from then on nothing would ever be written, see
+			// https://github.com/Tobias-Bonsack/Tonsias/issues/53
+			_notSavedEvents.clear();
+			_notSavedEvents.add(START_EVENT);
+		}
 
-		_notSavedEvents.clear();
-		_notSavedEvents.add(START_EVENT);
+		if (failures.getSuppressed().length > 0) {
+			throw failures;
+		}
+	}
+
+	/**
+	 * Runs one step of the save and keeps what it threw instead of letting it end
+	 * the save - the other three steps have files of their own to write, and they
+	 * are not lost because one of them could not.
+	 */
+	private void attempt(CompletionException failures, Runnable step) {
+		try {
+			step.run();
+		} catch (RuntimeException e) {
+			failures.addSuppressed(e);
+		}
 	}
 
 	private void handleSingleValueEvents(Event event, Set<String> singlevalueKeysToSave,

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
@@ -1,6 +1,7 @@
 package de.tonsias.basis.osgi.impl;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -188,6 +189,10 @@ public class InstanzServiceImpl implements IInstanzService {
 			try {
 				// the delete service works on files, the delta bookkeeping only knows keys
 				_deleteService.deleteFile(PATH + key + ".json");
+			} catch (NoSuchFileException e) {
+				// no file is the end state a delete is after - an instanz created and
+				// dropped again before any save never had one, see
+				// https://github.com/Tobias-Bonsack/Tonsias/issues/53
 			} catch (IOException e) {
 				ex.addSuppressed(e);
 			}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -202,27 +202,34 @@ public class SingleValueServiceImpl implements ISingleValueService {
 	 * The delta bookkeeping only knows keys, the delete service works on files -
 	 * and which folder a value lives in depends on its type. A value that is no
 	 * longer cached no longer tells its type, so every folder is tried until one of
-	 * them holds the file.
+	 * them holds the file. Finding it in none of them is no failure either: a value
+	 * created and deleted before any save never got written, and no file is what
+	 * the delete was after, see
+	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/53">#53</a>.
 	 */
 	private void deleteFile(String key) throws IOException {
 		ISingleValue<?> cached = _cache.get(key);
 		if (cached != null) {
-			_deleteService.deleteFile(cached.getPath() + key + ".json");
+			deleteIfPresent(cached.getPath() + key + ".json");
 			return;
 		}
 
-		IOException notFound = null;
 		for (SingleValueType type : SingleValueType.values()) {
-			try {
-				_deleteService.deleteFile(type.getPath() + key + ".json");
+			if (deleteIfPresent(type.getPath() + key + ".json")) {
 				return;
-			} catch (NoSuchFileException e) {
-				notFound = e;
 			}
 		}
+	}
 
-		if (notFound != null) {
-			throw notFound;
+	/**
+	 * @return whether there was a file at that path - which is the only way the
+	 *         folder search can tell it has found the right folder
+	 */
+	private boolean deleteIfPresent(String path) throws IOException {
+		try {
+			return _deleteService.deleteFile(path);
+		} catch (NoSuchFileException e) {
+			return false;
 		}
 	}
 

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IDeltaService.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IDeltaService.java
@@ -14,6 +14,13 @@ public interface IDeltaService extends EventHandler {
 
 	/**
 	 * Save all changes on the model.
+	 * <p>
+	 * Every part of the save is attempted, and the log is emptied either way - it
+	 * describes the difference against the disk, and a set that was offered once is
+	 * not offered again. What failed is carried out as suppressed exceptions of a
+	 * {@link java.util.concurrent.CompletionException}, so a caller can report it,
+	 * but the next save starts from what happened after this one.
+	 * </p>
 	 */
 	void saveDeltas();
 


### PR DESCRIPTION
Behebt #53.

## Problem

`DeltaServiceImpl.saveDeltas()` setzte sein Log erst **hinter** allen vier Service-Aufrufen zurück, und `deleteAll(..)` warf, sobald auch nur eine Datei nicht gefunden wurde. Ein Delete für etwas, das nie geschrieben wurde, hatte damit zwei Folgen:

1. Die Single-Value-Seite wurde gar nicht mehr gespeichert — Änderungen an Werten gingen bei diesem Speichern verloren.
2. Das Log blieb stehen. Beim nächsten `saveDeltas()` wurde dieselbe Menge erneut gefaltet, derselbe Delete schlug erneut fehl, das Log wuchs weiter. Ab da speicherte die Anwendung nichts mehr, ohne dass es sichtbar wurde.

## Lösung

Beide Fragen aus dem Issue, getrennt beantwortet:

**Ist es überhaupt ein Fehler?** Nein — eine fehlende Datei ist der gewünschte Endzustand. `NoSuchFileException` zählt jetzt als Erfolg, in `InstanzServiceImpl.deleteAll(..)` ebenso wie in der Ordnersuche von `SingleValueServiceImpl`. Dort war es etwas subtiler, weil die Suche `NoSuchFileException` benutzt, um im nächsten Ordner weiterzusuchen: das neue `deleteIfPresent(..)` gibt zurück, *ob* dort eine Datei lag, und „in keinem Ordner" ist kein Fehler mehr. Damit verschwindet der häufigste Auslöser ganz.

**Robustheit:** `saveDeltas()` führt alle vier Schritte durch, sammelt ihre Fehler als suppressed einer `CompletionException` und setzt das Log in einem `finally` zurück. Das Log ist die Differenz zur Platte — eine Menge, die einmal angeboten wurde, wird nicht erneut angeboten. Der Aufrufer erfährt trotzdem, was schiefging.

## Tests

- `DeltaSaveFailureSystemTest` (neu, 7 Tests): Delete ohne Datei ist kein Fehler (Instanz und Single Value, direkt und über `saveDeltas()`); ein Wert, der über zwei Saves zweimal gelöscht wird; und für den echten Fehlerfall ein Pfad, der sich nicht löschen lässt — dahinter laufen die restlichen Schritte weiter, der Fehler erreicht den Aufrufer, und das Log ist danach trotzdem leer, der nächste Save schreibt wieder.
- `InstanzServiceSystemTest` / `SingleValueServiceSystemTest`: die beiden Tests, die „kein File = Fehler" festhielten, beschreiben jetzt den neuen Vertrag. „Ein Fehler verdeckt die anderen nicht" bleibt erhalten, mit zwei echten Fehlern statt zwei fehlenden Dateien.
- `ProductRuntime.flushDeltas()` schrumpft wie im Issue vorgesehen wieder auf ein `saveDeltas()`; die Rettung von Hand entfällt. Neu sind `ProductRuntime.block(..)` / `unblock(..)`, mit denen ein Test einen Delete wirklich scheitern lassen kann. Dasselbe gilt für `DeltaPersistenceSystemTest.flush()`.
- `CLAUDE.md` an den neuen Vertrag angepasst.

`.\build.ps1` ist grün (361 Tests, 0 Failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)