### PR TITLE
fix #56: Injektionsreihenfolge des DeltaService explizit machen

### DIFF
--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/E4ServiceContext.java
@@ -26,8 +26,9 @@ import de.tonsias.basis.osgi.util.ChangePropagationListener;
  * activating.
  * </p>
  * <p>
- * Requesting the two keys once from the OSGi service context is enough: both
- * context functions register their result as an OSGi service, after which
+ * Requesting {@link IDeltaService} once from the OSGi service context is
+ * enough: its context function asks for the bridge before building, so both
+ * functions run and register their result as an OSGi service, after which
  * Declarative Services can satisfy the dependent components and
  * {@code OsgiUtil.getService(..)} resolves as it does in the product.
  * </p>
@@ -57,8 +58,10 @@ public final class E4ServiceContext {
 		BundleContext bundleContext = FrameworkUtil.getBundle(E4ServiceContext.class).getBundleContext();
 		IEclipseContext context = EclipseContextFactory.getServiceContext(bundleContext);
 
-		// order matters: the delta service depends on the bridge
-		context.get(IEventBrokerBridge.class.getName());
+		// asking for the delta service is enough: DeltaServiceContextFunction asks for
+		// the bridge before it builds, so the bridge is registered on the way. Nothing
+		// here repeats that order - if it were dropped over there, the whole suite
+		// would stop coming up right here.
 		context.get(IDeltaService.class.getName());
 
 		// Application.e4xmi contributes this as an addon, which is what makes its

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ContextFunctionSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ContextFunctionSystemTest.java
@@ -20,6 +20,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 
+import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IDeltaService;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
@@ -143,6 +144,31 @@ public class ContextFunctionSystemTest {
 		ProductRuntime.deltaService().saveDeltas();
 
 		assertThat(fromPart.getDeltas(), contains(IDeltaService.START_EVENT));
+	}
+
+	/**
+	 * A context that asks for nothing but the delta service still gets one that is
+	 * fully built.
+	 * <p>
+	 * The impl injects {@code IInstanzService} and {@code ISingleValueService}
+	 * alongside the bridge, and those two only activate once the bridge stands in
+	 * the registry - so the function asks for the bridge before it builds, instead
+	 * of leaving that to the order in which the injector walks the impl's fields.
+	 * Missing one of the two would not leave a field null, it would fail the
+	 * injection outright, so what the save reaches here is the whole of it.
+	 * </p>
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/56">#56</a>
+	 */
+	@Test
+	void testDeltaService_isBuiltWithTheBridgeAndBothServices() {
+		IDeltaService fromPart = injectedInto(partContext("only the delta service"), IDeltaService.class);
+		IInstanz created = _inse.createInstanz(ROOT, Type.SEND);
+
+		fromPart.saveDeltas();
+
+		assertThat(OsgiUtil.getService(IEventBrokerBridge.class), is(notNullValue()));
+		assertThat(ProductRuntime.instanzFileExists(created.getOwnKey()), is(true));
 	}
 
 	/**

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/DeltaServiceContextFunction.java
@@ -7,6 +7,7 @@ import org.osgi.service.component.annotations.Component;
 
 import de.tonsias.basis.osgi.impl.DeltaServiceImpl;
 import de.tonsias.basis.osgi.intf.IDeltaService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 
 /**
  * There is exactly one delta log in the application, see
@@ -23,10 +24,17 @@ public class DeltaServiceContextFunction extends SharedInstanceContextFunction<I
 
 	@Override
 	protected IDeltaService create(IEclipseContext context) {
-		// the impl also injects IInstanzService and ISingleValueService, and those only
-		// activate once the bridge is registered - which happens while its own field is
-		// injected. That the bridge comes first is the field order and nothing else,
-		// see https://github.com/Tobias-Bonsack/Tonsias/issues/56
+		// The impl also injects IInstanzService and ISingleValueService. Those two are
+		// DS components with a mandatory reference to IEventBrokerBridge, so they only
+		// activate once the bridge stands in the service registry - and it gets there
+		// by a context being asked for it, which is what this line does. Asking here
+		// keeps the order written down: leaving it to the injection of the impl's own
+		// bridge field would make start-up depend on the order in which
+		// Class#getDeclaredFields() hands the three fields out, and that order is
+		// explicitly not guaranteed. See
+		// https://github.com/Tobias-Bonsack/Tonsias/issues/56
+		context.get(IEventBrokerBridge.class.getName());
+
 		DeltaServiceImpl deltaService = ContextInjectionFactory.make(DeltaServiceImpl.class, context);
 		deltaService.postConstruct();
 		return deltaService;


### PR DESCRIPTION
Behebt #56.

## Was war

`DeltaServiceImpl` laesst sich `IEventBrokerBridge`, `IInstanzService` und `ISingleValueService` injizieren. Die letzten beiden sind DS-Komponenten mit einer mandatory `@Reference IEventBrokerBridge`, aktivieren also erst, wenn die Bridge in der Service-Registry steht — und dorthin kommt sie nur, weil ein Context nach ihrem Key gefragt wird. Bisher passierte genau das beim Injizieren des Bridge-Feldes. Dass dieses Feld zuerst drankommt, war allein die Reihenfolge aus `Class#getDeclaredFields()`, die die JLS ausdruecklich nicht garantiert: wer die drei Felder umsortiert, bekommt eine `InjectionException` beim Start und keinen Hinweis darauf, warum.

## Was jetzt

`DeltaServiceContextFunction.create(..)` fragt den Context einmal nach der Bridge, bevor `ContextInjectionFactory.make(..)` laeuft. Die Reihenfolge steht damit an einer Stelle und ist kommentiert; die Feldreihenfolge im Impl spielt keine Rolle mehr.

## Wie es abgesichert ist

`E4ServiceContext.prime()` wiederholte die Reihenfolge bisher selbst (`get(IEventBrokerBridge)` vor `get(IDeltaService)`) und haette den Fehler damit weiter verdeckt. Es fragt jetzt nur noch nach `IDeltaService`. Die gesamte Suite in drei Testbundles kommt also ueber die neue Zeile hoch — faellt sie weg, scheitert schon das Priming.

Dazu ein Test in `ContextFunctionSystemTest`: ein Context, der nach nichts als dem Delta-Service fragt, bekommt einen vollstaendig gebauten, dessen `saveDeltas()` die Instanz auf die Platte bringt.

`.\build.ps1` gruen: 372 Tests, 0 Failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)