### PR TITLE
docs #57: falsche Behauptung ueber fehlende Service-Component-XMLs streichen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ delta.view.*         the Delta view feature: logic / ui (fragment.e4xmi) / ui.te
 
 **Dependency injection — three mechanisms coexist.**
 
-1. **DS `@Component` + `@Reference`** for the plain services. Components are declared by **hand-maintained XML in `OSGI-INF/` referenced from `Service-Component:`** — adding one means both edits. (`de.tonsias.basis.osgi/META-INF/MANIFEST.MF` still lists two `…osgi.util.*.xml` files that do not exist.)
+1. **DS `@Component` + `@Reference`** for the plain services. Components are declared by **hand-maintained XML in `OSGI-INF/` referenced from `Service-Component:`** — adding one means both edits.
 2. **`ContextFunction`** for services needing the e4 context (`EventBrokerContextFunction`, `DeltaServiceContextFunction`). Both extend `SharedInstanceContextFunction`, which builds the instance once out of the bundle's own service context and answers every later `compute(..)` out of the service registry — an e4 context caches per *asking* context, so a per-call instance would give every part its own delta log.
 3. **`OsgiUtil.lazyLoading(Class, Consumer)`** for code constructed before OSGi is ready (`ChangePropagationListener`).
 


### PR DESCRIPTION
Behebt #57.

`CLAUDE.md` behauptete im Abschnitt zur Dependency Injection:

> (`de.tonsias.basis.osgi/META-INF/MANIFEST.MF` still lists two `…osgi.util.*.xml` files that do not exist.)

Beide Dateien existieren:

```
de.tonsias.basis.osgi/OSGI-INF/de.tonsias.basis.osgi.util.DeltaServiceContextFunction.xml
de.tonsias.basis.osgi/OSGI-INF/de.tonsias.basis.osgi.util.EventBrokerContextFunction.xml
```

Der `Service-Component:`-Header listet genau sechs XMLs, und alle sechs liegen in `OSGI-INF/`. Fehlte eines davon, wuerde die zugehoerige Komponente nie aktivieren und die Suite waere rot.

Der Klammersatz ist gestrichen. Die Aussage davor — eine neue Komponente braucht zwei Aenderungen, XML plus Header-Eintrag — bleibt stehen und ist der eigentliche Punkt der Stelle.

Reine Dokumentationsaenderung, kein Code beruehrt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)