### PR TITLE
SINGLE_FLOAT als vierter Wertetyp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to Tonsias are documented here. The format follows
 
 Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 
+### Added
+
+- `SingleFloatValue`, a fourth attribute type for decimal numbers, alongside string,
+  integer and boolean. It is created from the model view or while creating an instanz,
+  edited in the instanz view, and stored under `single_value/float/`. Only decimal
+  notation is accepted — `NaN`, `Infinity`, `1e5` and the German `3,14` are rejected
+  instead of turning into a number nobody typed, and the dialog greys out its OK button
+  on exactly that rule.
+
 ### Changed — tests
 
 - Every test is now a system test. The mock-based tests have been rewritten to drive the

--- a/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/system/LoadServiceSystemTest.java
+++ b/de.tonsias.basis.data.access.test/src/de/tonsias/basis/data/access/test/system/LoadServiceSystemTest.java
@@ -22,6 +22,7 @@ import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.Instanz;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 
@@ -61,6 +62,7 @@ public class LoadServiceSystemTest {
 		saved.addValuekeys(SingleValueType.SINGLE_STRING, java.util.Map.entry("sKey", "sName"));
 		saved.addValuekeys(SingleValueType.SINGLE_INTEGER, java.util.Map.entry("iKey", "iName"));
 		saved.addValuekeys(SingleValueType.SINGLE_BOOLEAN, java.util.Map.entry("bKey", "bName"));
+		saved.addValuekeys(SingleValueType.SINGLE_FLOAT, java.util.Map.entry("fKey", "fName"));
 
 		_saveService.safeAsGson(saved, saved.getClass());
 		IInstanz loaded = _loadService.loadFromGson("instanz/load_bimap", Instanz.class);
@@ -68,6 +70,7 @@ public class LoadServiceSystemTest {
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_STRING), hasEntry("sKey", "sName"));
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_INTEGER), hasEntry("iKey", "iName"));
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_BOOLEAN), hasEntry("bKey", "bName"));
+		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_FLOAT), hasEntry("fKey", "fName"));
 		// the inverse view is what TreeLabelProvider looks a name up in
 		assertThat(loaded.getSingleValues(SingleValueType.SINGLE_STRING).inverse().get("sName"), is("sKey"));
 	}
@@ -102,6 +105,22 @@ public class LoadServiceSystemTest {
 
 		assertThat(loaded.getValue(), is(42));
 		assertThat(loaded.getConnectedInstanzKeys(), contains("owner"));
+	}
+
+	/**
+	 * {@code ASingleValue} declares its value as the type variable {@code T}, which
+	 * is erased in the field - Gson has to resolve it through the concrete class to
+	 * read a JSON number back as a {@code Float} rather than as a {@code Double}.
+	 */
+	@Test
+	void testLoadFromGson_roundTripOfAFloatValue() {
+		SingleFloatValue saved = new SingleFloatValue("load_float");
+		saved.tryToSetValue(3.14f);
+
+		_saveService.safeAsGson(saved, saved.getClass());
+		SingleFloatValue loaded = _loadService.loadFromGson("single_value/float/load_float", SingleFloatValue.class);
+
+		assertThat(loaded.getValue(), is(3.14f));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/enums/SingleValueTypeTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/enums/SingleValueTypeTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -36,6 +37,11 @@ public class SingleValueTypeTest {
 	void testGetByClass_booleanValue() {
 		assertThat(SingleValueType.getByClass(SingleBooleanValue.class),
 				is(Optional.of(SingleValueType.SINGLE_BOOLEAN)));
+	}
+
+	@Test
+	void testGetByClass_floatValue() {
+		assertThat(SingleValueType.getByClass(SingleFloatValue.class), is(Optional.of(SingleValueType.SINGLE_FLOAT)));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleFloatValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleFloatValueTest.java
@@ -1,0 +1,86 @@
+package de.tonsias.basis.model.test.value;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
+
+public class SingleFloatValueTest {
+
+	@Test
+	void testNewValue_startsAtZero() {
+		assertThat(new SingleFloatValue("k").getValue(), is(0.0f));
+	}
+
+	@Test
+	void testGetPath_matchesTheEnum() {
+		assertThat(new SingleFloatValue("k").getPath(), is(SingleValueType.SINGLE_FLOAT.getPath()));
+	}
+
+	@Test
+	void testTryToSetValue_float() {
+		SingleFloatValue value = new SingleFloatValue("k");
+
+		assertThat(value.tryToSetValue(3.14f), is(true));
+		assertThat(value.getValue(), is(3.14f));
+	}
+
+	@Test
+	void testTryToSetValue_sameFloatIsNoChange() {
+		SingleFloatValue value = new SingleFloatValue("k");
+		value.tryToSetValue(3.14f);
+
+		assertThat(value.tryToSetValue(3.14f), is(false));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "3.14, 3.14", "-0.5, -0.5", "7, 7.0", "0042, 42.0", "  1.25  , 1.25" })
+	void testTryToSetValue_parsableString(String input, float expected) {
+		SingleFloatValue value = new SingleFloatValue("k");
+
+		assertThat(value.tryToSetValue(input), is(true));
+		assertThat(value.getValue(), is(expected));
+	}
+
+	/**
+	 * "3,14" is the German notation and the rest is what {@link Float#parseFloat}
+	 * would take beyond decimal notation - all of it is rejected instead of turning
+	 * into a number nobody typed.
+	 */
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(strings = { "", "  ", "abc", "3,14", "NaN", "Infinity", "-Infinity", "1e5", "3f", "3d", "0x1p3", "3.",
+			".5", "1_000" })
+	void testTryToSetValue_unparsableInputIsRejected(Object input) {
+		SingleFloatValue value = new SingleFloatValue("k");
+		value.tryToSetValue(1.5f);
+
+		assertThat(value.tryToSetValue(input), is(false));
+		assertThat(value.getValue(), is(1.5f));
+	}
+
+	@Test
+	void testTryToSetValue_integerIsRejected() {
+		// tryToSetValue takes an Object and the widgets hand their input on as text -
+		// a bare Integer is neither, and must not slip past as a Float
+		SingleFloatValue value = new SingleFloatValue("k");
+
+		assertThat(value.tryToSetValue(Integer.valueOf(7)), is(false));
+		assertThat(value.getValue(), is(0.0f));
+	}
+
+	@Test
+	void testToString_containsKeyValueAndSimpleClassName() {
+		SingleFloatValue value = new SingleFloatValue("k");
+		value.tryToSetValue(5.5f);
+
+		assertThat(value.toString(), is("k 5.5 : SingleFloatValue"));
+	}
+}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -14,7 +15,8 @@ public enum SingleValueType {
 	// the ordinals, so reordering would move existing selections
 	SINGLE_STRING(SingleStringValue.class, "single_value/string/"),
 	SINGLE_INTEGER(SingleIntegerValue.class, "single_value/integer/"),
-	SINGLE_BOOLEAN(SingleBooleanValue.class, "single_value/boolean/");
+	SINGLE_BOOLEAN(SingleBooleanValue.class, "single_value/boolean/"),
+	SINGLE_FLOAT(SingleFloatValue.class, "single_value/float/");
 
 	private final Class<? extends ISingleValue<?>> _clazz;
 

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -39,6 +39,8 @@ public abstract class AInstanz implements IInstanz {
 
 	private BiMap<String, String> _singleBooleanKeyValueMap;
 
+	private BiMap<String, String> _singleFloatKeyValueMap;
+
 	public AInstanz(String key) {
 		this._ownKey = key;
 	}
@@ -50,13 +52,14 @@ public abstract class AInstanz implements IInstanz {
 
 	public AInstanz(String _parentKey, String _ownKey, Set<String> _childKeys,
 			BiMap<String, String> _singleStringKeyValueMap, BiMap<String, String> _singleIntegerKeyValueMap,
-			BiMap<String, String> _singleBooleanKeyValueMap) {
+			BiMap<String, String> _singleBooleanKeyValueMap, BiMap<String, String> _singleFloatKeyValueMap) {
 		this._parentKey = _parentKey;
 		this._ownKey = _ownKey;
 		this._childKeys = _childKeys;
 		this._singleStringKeyValueMap = _singleStringKeyValueMap;
 		this._singleIntegerKeyValueMap = _singleIntegerKeyValueMap;
 		this._singleBooleanKeyValueMap = _singleBooleanKeyValueMap;
+		this._singleFloatKeyValueMap = _singleFloatKeyValueMap;
 	}
 
 	@Override
@@ -125,6 +128,11 @@ public abstract class AInstanz implements IInstanz {
 				_singleBooleanKeyValueMap = HashBiMap.create();
 			}
 			return _singleBooleanKeyValueMap;
+		case SINGLE_FLOAT:
+			if (_singleFloatKeyValueMap == null) {
+				_singleFloatKeyValueMap = HashBiMap.create();
+			}
+			return _singleFloatKeyValueMap;
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleFloatValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleFloatValue.java
@@ -1,0 +1,61 @@
+package de.tonsias.basis.model.impl.value;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+
+public class SingleFloatValue extends ASingleValue<Float> {
+
+	/**
+	 * The decimal notation this type accepts as text, shared with the dialog that
+	 * greys out its OK button on anything else.
+	 */
+	public static final String DECIMAL_PATTERN = "-?\\d+(\\.\\d+)?";
+
+	private static final Pattern DECIMAL = Pattern.compile(DECIMAL_PATTERN);
+
+	public SingleFloatValue(String key) {
+		super(key);
+		this.setValue(0.0f);
+	}
+
+	public SingleFloatValue(String key, float value, Set<String> connectedInstanzes) {
+		super(key, value, connectedInstanzes);
+	}
+
+	/**
+	 * Only decimal notation is accepted - {@link Float#parseFloat} would also read
+	 * "NaN", "Infinity", "1e5", "3f" and "0x1p3", none of which anybody types into
+	 * a value field on purpose. They are rejected instead of being folded into a
+	 * surprising number.
+	 */
+	@Override
+	public boolean tryToSetValue(Object value) {
+		if (value instanceof Float f) {
+			return setValue(f);
+		} else if (value instanceof String s) {
+			String trimmed = s.strip();
+			if (DECIMAL.matcher(trimmed).matches()) {
+				return setValue(Float.valueOf(trimmed));
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String getPath() {
+		return SingleValueType.SINGLE_FLOAT.getPath();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(this.getOwnKey()).append(" ");
+		builder.append(this.getValue()).append(" ");
+		String[] string = this.getClass().toString().split("\\.");
+		builder.append(": ").append(string[string.length - 1]);
+		return builder.toString();
+	}
+
+}

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/EventChainSystemTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -546,6 +547,30 @@ public class EventChainSystemTest {
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_BOOLEAN).get(value.getOwnKey()), is("flag"));
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).keySet(), is(empty()));
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_INTEGER).keySet(), is(empty()));
+	}
+
+	/**
+	 * The same for the fourth type. Its value comes from the dialog as text, so
+	 * this is also where the chain is checked with a string that has to be parsed
+	 * on the way in.
+	 */
+	@Test
+	void testCreateSingleValue_float_usesItsOwnTypeThroughoutTheChain() {
+		IInstanz owner = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		SingleFloatValue value = _svs.createNew(SingleFloatValue.class, owner.getOwnKey(), "ratio", "3.14", Type.SEND);
+
+		assertThat(value.getValue(), is(3.14f));
+		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
+				is(SingleValueType.SINGLE_FLOAT));
+		assertThat(_recorder.onlyDataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class)
+				._singleValuetype(), is(SingleValueType.SINGLE_FLOAT));
+
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_FLOAT).get(value.getOwnKey()), is("ratio"));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).keySet(), is(empty()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_INTEGER).keySet(), is(empty()));
+		assertThat(owner.getSingleValues(SingleValueType.SINGLE_BOOLEAN).keySet(), is(empty()));
 	}
 
 	/**

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -124,6 +125,40 @@ public class SingleValueServiceSystemTest {
 		assertThat(_owner.getSingleValues(SingleValueType.SINGLE_BOOLEAN).get(created.getOwnKey()), is("flag"));
 		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
 				is(SingleValueType.SINGLE_BOOLEAN));
+	}
+
+	@Test
+	void testCreateNew_floatValueLandsInTheFloatMap() {
+		_recorder.clear();
+
+		// the dialog and InstanzView hand the value on as text
+		SingleFloatValue created = _svs.createNew(SingleFloatValue.class, _owner.getOwnKey(), "ratio", "3.14",
+				Type.SEND);
+
+		assertThat(created.getValue(), is(3.14f));
+		assertThat(_owner.getSingleValues(SingleValueType.SINGLE_FLOAT).get(created.getOwnKey()), is("ratio"));
+		assertThat(_owner.getSingleValues(SingleValueType.SINGLE_INTEGER).containsKey(created.getOwnKey()), is(false));
+		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
+				is(SingleValueType.SINGLE_FLOAT));
+	}
+
+	/**
+	 * The whole way out and back in: the value goes to its own folder and comes off
+	 * disk as the same number, through the type variable {@code ASingleValue}
+	 * declares its value with.
+	 */
+	@Test
+	void testSaveAll_aFloatValueSurvivesTheRoundTripThroughItsOwnFolder() {
+		SingleFloatValue created = _svs.createNew(SingleFloatValue.class, _owner.getOwnKey(), "ratio", "-0.5",
+				Type.SEND);
+
+		assertThat(_svs.saveAll(Set.of(created.getOwnKey())), is(true));
+
+		assertThat(ProductRuntime.valueFileExists(SingleValueType.SINGLE_FLOAT, created.getOwnKey()), is(true));
+		SingleFloatValue reloaded = ProductRuntime.reloadValue(SingleValueType.SINGLE_FLOAT, created.getOwnKey(),
+				SingleFloatValue.class);
+		assertThat(reloaded.getValue(), is(-0.5f));
+		assertThat(reloaded.getConnectedInstanzKeys(), contains(_owner.getOwnKey()));
 	}
 
 	@Test

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -24,6 +24,7 @@ import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -120,6 +121,8 @@ public class SingleValueServiceImpl implements ISingleValueService {
 			return (E) new SingleIntegerValue(key);
 		case SINGLE_BOOLEAN:
 			return (E) new SingleBooleanValue(key);
+		case SINGLE_FLOAT:
+			return (E) new SingleFloatValue(key);
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
@@ -12,6 +12,7 @@ constant_remove        = Remove
 constant_save          = Save
 constant_singleValue   = Single Value
 constant_type_boolean  = Boolean
+constant_type_float    = Float
 constant_type_integer  = Integer
 constant_type_string   = String
 constant_value         = Value

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
@@ -12,6 +12,7 @@ constant_remove        = Entfernen
 constant_save          = Speichern
 constant_singleValue   = Einzelwert
 constant_type_boolean  = Wahrheitswert
+constant_type_float    = Kommazahl
 constant_type_integer  = Ganzzahl
 constant_type_string   = Text
 constant_value         = Wert

--- a/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
+++ b/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
@@ -14,6 +14,7 @@ public class Messages {
 	public String constant_save;
 	public String constant_singleValue;
 	public String constant_type_boolean;
+	public String constant_type_float;
 	public String constant_type_integer;
 	public String constant_type_string;
 	public String constant_value;

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
@@ -20,6 +20,7 @@ class MessagesUtilTest {
 		messages.constant_type_string = "String";
 		messages.constant_type_integer = "Integer";
 		messages.constant_type_boolean = "Boolean";
+		messages.constant_type_float = "Float";
 		messages.pref_currentKey = "Current key";
 		messages.pref_modelViewText = "Model view text";
 		messages.pref_enableValues = "Enable values";
@@ -34,6 +35,7 @@ class MessagesUtilTest {
 		assertEquals("String", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_STRING));
 		assertEquals("Integer", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_INTEGER));
 		assertEquals("Boolean", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_BOOLEAN));
+		assertEquals("Float", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_FLOAT));
 	}
 
 	/**

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
@@ -63,7 +63,11 @@ public class FloatValueDialog extends AValueDialog<SingleFloatValue, Text> {
 
 	/**
 	 * The rule {@link SingleFloatValue#tryToSetValue} applies, so the button is
-	 * disabled for exactly the input that would be discarded.
+	 * disabled for exactly the input that would be discarded - from the first
+	 * change on, that is: the button starts out enabled over an empty field, like
+	 * the one in {@link IntegerValueDialog}.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/62">#62</a>
 	 */
 	private boolean isFloat(String str) {
 		return str != null && str.strip().matches(SingleFloatValue.DECIMAL_PATTERN);

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
@@ -1,0 +1,76 @@
+package de.tonsias.basis.ui.dialog;
+
+import java.util.Optional;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.widgets.TextFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
+import de.tonsias.basis.ui.i18n.Messages;
+
+public class FloatValueDialog extends AValueDialog<SingleFloatValue, Text> {
+
+	public FloatValueDialog(Shell parentShell, SingleFloatValue floatValue, IInstanz instanz, Messages messages) {
+		super(parentShell, floatValue, instanz, messages);
+	}
+
+	public FloatValueDialog(Shell parentShell, IInstanz instanz, Messages messages) {
+		this(parentShell, null, instanz, messages);
+	}
+
+	@Override
+	protected Text createValueControl(Composite composite, String valueString) {
+		return TextFactory.newText(SWT.None).text(valueString)
+				.layoutData(GridDataFactory.fillDefaults().grab(true, false).create()).enabled(true).create(composite);
+	}
+
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Control control = super.createDialogArea(parent);
+
+		_valueControl.addModifyListener(event -> {
+			getButton(IDialogConstants.OK_ID).setEnabled(isFloat(_valueControl.getText()));
+		});
+
+		return control;
+	}
+
+	@Override
+	protected void okPressed() {
+		if (_value.isEmpty()) {
+			_value = Optional.of(//
+					_sVService.createNew(SingleFloatValue.class, //
+							_instanz.getOwnKey(), //
+							_nameText.getText(), //
+							_valueControl.getText(), //
+							IEventBrokerBridge.Type.POST//
+					));
+		} else {
+			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
+					IEventBrokerBridge.Type.POST);
+		}
+		super.okPressed();
+	}
+
+	/**
+	 * The rule {@link SingleFloatValue#tryToSetValue} applies, so the button is
+	 * disabled for exactly the input that would be discarded.
+	 */
+	private boolean isFloat(String str) {
+		return str != null && str.strip().matches(SingleFloatValue.DECIMAL_PATTERN);
+	}
+
+	@Override
+	SingleValueType getType() {
+		return SingleValueType.SINGLE_FLOAT;
+	}
+}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
@@ -189,7 +189,10 @@ public class InstanzView {
 	private void createSinlgeValueTexts(Group typeGroup, ISingleValue<?> singleValue) {
 		Control control = null;
 		switch (SingleValueType.getByClass(singleValue.getClass()).get()) {
+		// both numbers are entered in one line and travel on as text, which
+		// tryToSetValue parses - the only difference is what it accepts there
 		case SINGLE_INTEGER:
+		case SINGLE_FLOAT:
 			control = TextFactory.newText(SWT.None)//
 					.text(singleValue.getValue().toString())//
 					.onModify(event -> onSingleValueModify(singleValue, event))

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
@@ -31,6 +31,7 @@ import org.osgi.service.event.Event;
 
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
+import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -48,6 +49,7 @@ import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.osgi.intf.non.service.PreferenceEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
 import de.tonsias.basis.ui.dialog.BooleanValueDialog;
+import de.tonsias.basis.ui.dialog.FloatValueDialog;
 import de.tonsias.basis.ui.dialog.IntegerValueDialog;
 import de.tonsias.basis.ui.dialog.StringValueDialog;
 import de.tonsias.basis.ui.handler.CreateInstanzOperation;
@@ -284,6 +286,31 @@ public class ModelView {
 				int open = dialog.open();
 				if (open == Window.OK) {
 					SingleBooleanValue singleValue = dialog.getSingleValue();
+					new TreeNodeWrapper(singleValue, parent);
+					_treeViewer.refresh(parent);
+				}
+
+			}
+		});
+
+		MenuItem createFloatValueItem = new MenuItem(singleValueMenu, SWT.None);
+		createFloatValueItem.setText(_messages.constant_type_float);
+
+		createFloatValueItem.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				TreeItem[] selection = tree.getSelection();
+				if (selection.length != 1) {
+					return;
+				}
+
+				TreeNodeWrapper parent = (TreeNodeWrapper) selection[0].getData();
+				IInstanz parentObject = (IInstanz) parent.getObject();
+
+				FloatValueDialog dialog = new FloatValueDialog(new Shell(), parentObject, _messages);
+				int open = dialog.open();
+				if (open == Window.OK) {
+					SingleFloatValue singleValue = dialog.getSingleValue();
 					new TreeNodeWrapper(singleValue, parent);
 					_treeViewer.refresh(parent);
 				}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
@@ -23,6 +23,8 @@ public class MessagesUtil {
 			return messages.constant_type_integer;
 		case SINGLE_BOOLEAN:
 			return messages.constant_type_boolean;
+		case SINGLE_FLOAT:
+			return messages.constant_type_float;
 		default:
 			return type.name();
 		}


### PR DESCRIPTION
Kommazahlen ließen sich bisher nur als Text ablegen — ohne Validierung und ohne Typinformation auf der Platte. `SINGLE_FLOAT` schließt die Lücke über den ganzen Stack, dem Weg folgend, den `SINGLE_BOOLEAN` schon gegangen ist.

## Was drin ist

**Modell** — `SingleFloatValue extends ASingleValue<Float>` mit dem Pfad `single_value/float/`, die Konstante ans Ende des Enums (die Combo-Box von `CreateInstanzDialog` hängt an den Ordinals), die passende `BiMap` in `AInstanz` und der Fall in der Fabrik `SingleValueServiceImpl.create`.

`tryToSetValue` nimmt ein `Float` und dezimale Schreibweise als Text. `Float.parseFloat` läse darüber hinaus auch `NaN`, `Infinity`, `1e5`, `3f` und `0x1p3` — nichts davon meint jemand, der in ein Wertfeld tippt, also wird es abgelehnt statt in eine überraschende Zahl gefaltet. Das deutsche `3,14` ebenso: es müsste sonst entweder `3` oder `314` werden.

**Oberfläche** — `FloatValueDialog` ist der `IntegerValueDialog` des neuen Typs, mit demselben einzeiligen Feld und einer anderen Regel für den OK-Button. Diese Regel ist das Muster, das `SingleFloatValue.tryToSetValue` anwendet, von dort geholt statt ein zweites Mal ausgeschrieben — der Button ist also für genau die Eingabe gesperrt, die das Modell verwerfen würde. `InstanzView` rendert den Typ neben `SINGLE_INTEGER`: beide Zahlen werden einzeilig eingegeben und gehen als Text weiter, sie unterscheiden sich nur darin, was beim Parsen durchkommt. `ModelView` bekommt den vierten Menüeintrag; `CreateInstanzDialog` brauchte nichts, es baut seine Auswahl aus `SingleValueType.values()`.

**Tests** — `SingleFloatValueTest` spiegelt `SingleIntegerValueTest` und pinnt die Annahmeregel fest. Der Weg auf die Platte wird zweimal geprüft, weil dies der erste Wert ist, den Gson durch die Typvariable von `ASingleValue` hindurch als etwas anderes lesen muss als das, worauf eine JSON-Zahl sonst fällt: einmal über den Load-Service allein, einmal über anlegen, speichern, neu laden. `EventChainSystemTest` bekommt den vierten Typ — und läuft dort mit einem Wert, der als Text ankommt, so wie der Dialog ihn übergibt.

`.\build.ps1` ist grün: 410 Tests, keine Fehler.

## Unterwegs gefunden, nicht hier behoben

- #60 — `SINGLE_BOOLEAN` steht nirgends im `CHANGELOG.md`, obwohl der Typ auf `main` ist.
- #61 — der lange Konstruktor von `AInstanz` wird von niemandem aufgerufen, wächst aber mit jedem Wertetyp um einen Parameter.
- #62 — der OK-Button beider Zahlendialoge ist beim Öffnen über einem leeren Feld aktiv und folgt dem Muster erst ab der ersten Änderung. `FloatValueDialog` wurde bewusst wie `IntegerValueDialog` gebaut und erbt die Lücke; ein Kommentar dort zeigt auf das Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)