### PR TITLE
docs #60: SingleBooleanValue im CHANGELOG nachtragen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 
 ### Added
 
+- `SingleBooleanValue`, a third attribute type for yes-or-no attributes, alongside
+  string and integer. It is created from the model view or while creating an instanz,
+  shown and toggled as a check box in the instanz view, and stored under
+  `single_value/boolean/`. Only the two literals `true` and `false` are accepted, so a
+  typo is rejected rather than silently clearing the value.
 - `SingleFloatValue`, a fourth attribute type for decimal numbers, alongside string,
   integer and boolean. It is created from the model view or while creating an instanz,
   edited in the instanz view, and stored under `single_value/float/`. Only decimal


### PR DESCRIPTION
Behebt #60.

`SingleBooleanValue` / `SINGLE_BOOLEAN` liegt seit e498c81 auf `main`, stand aber in keinem Abschnitt von `CHANGELOG.md`: `## [0.1.0]` ist älter als der Typ, und `## [Unreleased]` bekam seinen `### Added`-Abschnitt erst mit `SINGLE_FLOAT`. Wer die 0.2.0-Release-Notes aus dem Unreleased-Abschnitt schreibt, hätte einen kompletten Attributtyp übersehen.

Der neue Stichpunkt steht vor dem Float-Eintrag — der Boolean-Typ kam zuerst — und ist parallel dazu gebaut: wo er angelegt wird, wo er angezeigt wird, wo er auf der Platte landet, und was `tryToSetValue` akzeptiert.

Der Abschnitt *Known limitations* unter `## [0.1.0]` ("Single values are limited to string and integer") bleibt unverändert: er beschreibt den Stand von 0.1.0 und ist dafür richtig.

Reine Dokumentationsänderung, kein Code und keine Testressource betroffen — `.\build.ps1` wurde deshalb nicht gefahren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)