### PR TITLE
fix #61: den unbenutzten All-Fields-Konstruktor von AInstanz entfernen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 
 - Mockito, from every bundle manifest and from the target platform. Nothing uses a
   mocking framework any more.
+- The all-fields constructor of `AInstanz`. Nothing ever called it: instanzen are built
+  with `new Instanz(key)` and filled through `addValuekeys(..)`, and Gson constructs the
+  class without any constructor. It grew a parameter with every new value type, and
+  whoever had used it would have bypassed the lazy map creation in `getSingleValues` and
+  could have left a map at `null` ([#61]).
 
 ### Fixed — nothing yet, but found
 
@@ -53,6 +58,7 @@ same failure ([#53]).
 
 [#52]: https://github.com/Tobias-Bonsack/Tonsias/issues/52
 [#53]: https://github.com/Tobias-Bonsack/Tonsias/issues/53
+[#61]: https://github.com/Tobias-Bonsack/Tonsias/issues/61
 
 ## [0.1.0] - 2026-08-07
 

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -32,7 +32,11 @@ public abstract class AInstanz implements IInstanz {
 
 	// no field initializers: Gson constructs an AInstanz without a constructor and
 	// would leave a map absent from the json at null. getSingleValues is therefore
-	// the single place that creates one, for every type alike.
+	// the single place that creates one, for every type alike - and there is
+	// deliberately no constructor taking the maps, which would both bypass that and
+	// have to grow a parameter with every new SingleValueType. Fill an instanz
+	// through addValuekeys instead. See
+	// https://github.com/Tobias-Bonsack/Tonsias/issues/61
 	private BiMap<String, String> _singleStringKeyValueMap;
 
 	private BiMap<String, String> _singleIntegerKeyValueMap;
@@ -45,21 +49,11 @@ public abstract class AInstanz implements IInstanz {
 		this._ownKey = key;
 	}
 
+	// unreachable too: Instanz is the only subclass and passes on the key alone.
+	// See https://github.com/Tobias-Bonsack/Tonsias/issues/65
 	public AInstanz(String key, String parent) {
 		this._ownKey = key;
 		this._parentKey = parent;
-	}
-
-	public AInstanz(String _parentKey, String _ownKey, Set<String> _childKeys,
-			BiMap<String, String> _singleStringKeyValueMap, BiMap<String, String> _singleIntegerKeyValueMap,
-			BiMap<String, String> _singleBooleanKeyValueMap, BiMap<String, String> _singleFloatKeyValueMap) {
-		this._parentKey = _parentKey;
-		this._ownKey = _ownKey;
-		this._childKeys = _childKeys;
-		this._singleStringKeyValueMap = _singleStringKeyValueMap;
-		this._singleIntegerKeyValueMap = _singleIntegerKeyValueMap;
-		this._singleBooleanKeyValueMap = _singleBooleanKeyValueMap;
-		this._singleFloatKeyValueMap = _singleFloatKeyValueMap;
 	}
 
 	@Override


### PR DESCRIPTION
Behebt #61.

## Was geändert wurde

`AInstanz(String, String, Set<String>, BiMap, BiMap, BiMap, BiMap)` ist ersatzlos entfernt. Der Konstruktor hatte keinen einzigen Aufrufer:

- `Instanz` ist die einzige Unterklasse und reicht nur `super(key)` durch,
- `InstanzServiceImpl` baut mit `new Instanz(key)` (Z. 78 und 131),
- Gson konstruiert `AInstanz` ganz ohne Konstruktor — deshalb legt `getSingleValues` die BiMaps ja erst bei Bedarf an.

Mit `SINGLE_BOOLEAN` hatte er den sechsten Parameter bekommen, mit `SINGLE_FLOAT` den siebten. Jeder weitere Wertetyp haette die Signatur weiter verlaengert, und wer sie doch benutzt haette, waere an der Lazy-Initialisierung vorbei und haette eine Map auf `null` setzen koennen — was `TreeNodeWrapper` und `InstanzView` beim Durchlaufen aller Typen trifft.

Der Kommentar am Feldblock sagt jetzt, warum es einen solchen Konstruktor bewusst nicht gibt und dass `addValuekeys(..)` der Weg ist, damit der naechste Wertetyp ihn nicht wieder mitbringt. Ein Stichpunkt unter `### Removed` im `CHANGELOG.md` haelt fest, dass hier ein `public`-Konstruktor aus einem bereits veroeffentlichten Bundle verschwindet.

## Was dabei aufgefallen ist

`AInstanz(String key, String parent)` ist ebenfalls unerreichbar — `Instanz` hat keinen passenden Konstruktor, der ihn aufrufen wuerde. Das ist als #65 gemeldet und hier nicht angefasst; im Code steht ein Verweis darauf an der Stelle.

## Tests

Keine neuen Tests: entfernt wird Code, den kein Test und kein Produktionspfad je erreicht hat. `AInstanzTest` fuellt seine Instanz schon heute ueber `addValuekeys(..)` und laeuft unveraendert durch.

`.\build.ps1` ist gruen — 410 Tests, 0 Failures, 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)