### PR TITLE
fix value-dialogs: eine Regel je Zahlentyp, ein Urteil am OK-Button, ein ehrlicher CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,14 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   and then silently stored as `0`, `+5` is no longer refused although the model reads
   it, and a decimal number too big for a `float` is rejected instead of being stored as
   the `Infinity` the type promises never to hold ([#68]).
+- The reason a value dialog refuses a name is now on a label under the field, where it
+  can be read. It used to be handed to `Text.setMessage(..)`, the placeholder SWT only
+  draws over an empty field — so in the one case it was set for, a name someone had just
+  typed, it was never on screen and the red field stood there without a word ([#71]).
+- A value dialog opened on a stored value writes the value back, not only the name. The
+  field was prefilled, editable and read for the OK button, and its content was then
+  dropped on OK. `okPressed()` moved up into `AValueDialog`, which is where the four
+  dialogs only differed in how their widget is read ([#72]).
 
 [#52]: https://github.com/Tobias-Bonsack/Tonsias/issues/52
 [#53]: https://github.com/Tobias-Bonsack/Tonsias/issues/53
@@ -102,6 +110,8 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 [#65]: https://github.com/Tobias-Bonsack/Tonsias/issues/65
 [#67]: https://github.com/Tobias-Bonsack/Tonsias/issues/67
 [#68]: https://github.com/Tobias-Bonsack/Tonsias/issues/68
+[#71]: https://github.com/Tobias-Bonsack/Tonsias/issues/71
+[#72]: https://github.com/Tobias-Bonsack/Tonsias/issues/72
 
 ## [0.1.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,26 +52,56 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   class without any constructor. It grew a parameter with every new value type, and
   whoever had used it would have bypassed the lazy map creation in `getSingleValues` and
   could have left a map at `null` ([#61]).
+- The second constructor of `AInstanz`, the one taking a key and a parent key. `Instanz`
+  is its only subclass and passes on the key alone, so nothing could reach it — and a
+  parent set there would have been set past `IInstanzService`, without the other side
+  being pulled along and without a delta. `createInstanz(parentKey, Type)` is the way
+  ([#65]).
 
 ### Fixed
 
+- The e4 context functions hand out one shared service instance instead of building a
+  new one on every `compute(..)`. An e4 context caches per *asking* context, so the
+  Delta view used to render a different delta log than the one the save path empties
+  ([#52]).
+- `saveDeltas()` empties its log whatever happens: the reset moved into a `finally`, a
+  failing step is collected as a suppressed exception rather than ending the save, and a
+  delete that finds no file counts as done. One bad delete used to wedge every save that
+  followed ([#53]).
+- `DeltaServiceImpl` no longer depends on the order in which its fields happen to be
+  injected. `DeltaServiceContextFunction` asks the context for `IEventBrokerBridge`
+  before it builds, so the services that need the bridge are activated by the time their
+  turn comes, whatever order `Class#getDeclaredFields()` returns ([#56]).
+- `CLAUDE.md` no longer claims that two `OSGI-INF` component descriptions are missing —
+  they are there, and were all along ([#57]).
 - The OK button of a value dialog is now set from the dialog's own validation the
   moment the dialog is built, not only from the first keystroke on. A dialog opened
   for a new integer or float value used to offer OK over its empty field — pressing it
   created a value whose input `tryToSetValue` then rejected, silently leaving it at `0`
   or `0.0`. The rule lives in `AValueDialog.isValueAcceptable()` now, so every dialog
   answers for its own type in one place ([#62]).
-
-The rewrite surfaced two defects, filed rather than silently patched: the e4 context
-functions build a new service instance on every `compute(..)`, so the Delta view can
-render a different delta log than the save path uses ([#52]), and `saveDeltas()` does
-not reset its log when a delete fails, after which every following save repeats the
-same failure ([#53]).
+- The name check and the value check of a value dialog no longer overwrite each other's
+  verdict at the OK button. Both are asked in `AValueDialog.refreshOkButton()`, the one
+  place that sets it: a value the model would discard stayed discarded when the name is
+  touched, and a name another value already carries stays refused when the value is.
+  The name a stored value carries counts as its own, so editing it is not blocked
+  against itself ([#67]).
+- The number dialogs ask their type what it takes instead of matching a pattern of their
+  own. `SingleIntegerValue.accepts(..)` and `SingleFloatValue.accepts(..)` are the one
+  rule each, and `tryToSetValue` applies it itself: `99999999999` is no longer offered
+  and then silently stored as `0`, `+5` is no longer refused although the model reads
+  it, and a decimal number too big for a `float` is rejected instead of being stored as
+  the `Infinity` the type promises never to hold ([#68]).
 
 [#52]: https://github.com/Tobias-Bonsack/Tonsias/issues/52
 [#53]: https://github.com/Tobias-Bonsack/Tonsias/issues/53
-[#62]: https://github.com/Tobias-Bonsack/Tonsias/issues/62
+[#56]: https://github.com/Tobias-Bonsack/Tonsias/issues/56
+[#57]: https://github.com/Tobias-Bonsack/Tonsias/issues/57
 [#61]: https://github.com/Tobias-Bonsack/Tonsias/issues/61
+[#62]: https://github.com/Tobias-Bonsack/Tonsias/issues/62
+[#65]: https://github.com/Tobias-Bonsack/Tonsias/issues/65
+[#67]: https://github.com/Tobias-Bonsack/Tonsias/issues/67
+[#68]: https://github.com/Tobias-Bonsack/Tonsias/issues/68
 
 ## [0.1.0] - 2026-08-07
 

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleFloatValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleFloatValueTest.java
@@ -3,6 +3,8 @@ package de.tonsias.basis.model.test.value;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -64,6 +66,66 @@ public class SingleFloatValueTest {
 
 		assertThat(value.tryToSetValue(input), is(false));
 		assertThat(value.getValue(), is(1.5f));
+	}
+
+	/**
+	 * A one followed by forty zeros is decimal notation, so the notation alone lets
+	 * it through - {@link Float#parseFloat} then folds it to {@code Infinity}, the
+	 * very number this type promises not to store. It is rejected on the parsed
+	 * result instead.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "10000000000000000000000000000000000000000", "-10000000000000000000000000000000000000000",
+			"340282400000000000000000000000000000000000.0" })
+	void testTryToSetValue_numberTooBigForAFloatIsRejected(String input) {
+		SingleFloatValue value = new SingleFloatValue("k");
+		value.tryToSetValue(1.5f);
+
+		assertThat(value.tryToSetValue(input), is(false));
+		assertThat(value.getValue(), is(1.5f));
+	}
+
+	/** the same rule for a caller that already holds the float */
+	@Test
+	void testTryToSetValue_nonFiniteFloatIsRejected() {
+		SingleFloatValue value = new SingleFloatValue("k");
+		value.tryToSetValue(1.5f);
+
+		assertThat(value.tryToSetValue(Float.POSITIVE_INFINITY), is(false));
+		assertThat(value.tryToSetValue(Float.NEGATIVE_INFINITY), is(false));
+		assertThat(value.tryToSetValue(Float.NaN), is(false));
+		assertThat(value.getValue(), is(1.5f));
+	}
+
+	/**
+	 * {@code accepts} is what the dialog asks before it offers its OK button, so it
+	 * has to answer for the same input the same way {@code tryToSetValue} does.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "3.14", "-0.5", "7", "0042", "  1.25  " })
+	void testAccepts_agreesWithTryToSetValue_onWhatItTakes(String input) {
+		assertThat(SingleFloatValue.accepts(input), is(true));
+		// seeded away from every input, because setValue answers false for "already
+		// that value" as well
+		assertThat(new SingleFloatValue("k", Float.MIN_VALUE, Set.of()).tryToSetValue(input), is(true));
+	}
+
+	/** @see #testAccepts_agreesWithTryToSetValue_onWhatItTakes(String) */
+	@ParameterizedTest
+	@ValueSource(strings = { "", "  ", "abc", "3,14", "NaN", "Infinity", "1e5", "3f", "0x1p3", "3.", ".5",
+			"10000000000000000000000000000000000000000" })
+	void testAccepts_agreesWithTryToSetValue_onWhatItRejects(String input) {
+		assertThat(SingleFloatValue.accepts(input), is(false));
+		assertThat(new SingleFloatValue("k").tryToSetValue(input), is(false));
+	}
+
+	@Test
+	void testAccepts_null() {
+		assertThat(SingleFloatValue.accepts(null), is(false));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleIntegerValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleIntegerValueTest.java
@@ -3,6 +3,8 @@ package de.tonsias.basis.model.test.value;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -41,7 +43,7 @@ public class SingleIntegerValueTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource({ "7, 7", "-3, -3", "0042, 42" })
+	@CsvSource({ "7, 7", "-3, -3", "+5, 5", "0042, 42" })
 	void testTryToSetValue_parsableString(String input, int expected) {
 		SingleIntegerValue value = new SingleIntegerValue("k");
 
@@ -58,6 +60,36 @@ public class SingleIntegerValueTest {
 
 		assertThat(value.tryToSetValue(input), is(false));
 		assertThat(value.getValue(), is(11));
+	}
+
+	/**
+	 * {@code accepts} is what the dialog asks before it offers its OK button, so it
+	 * has to answer for the same input the same way {@code tryToSetValue} does - a
+	 * leading plus and a number past {@code Integer.MAX_VALUE} are where the dialog
+	 * used to have a rule of its own.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "7", "-3", "+5", "0042", "2147483647", "-2147483648" })
+	void testAccepts_agreesWithTryToSetValue_onWhatItTakes(String input) {
+		assertThat(SingleIntegerValue.accepts(input), is(true));
+		// seeded away from every input, because setValue answers false for "already
+		// that value" as well
+		assertThat(new SingleIntegerValue("k", Integer.MIN_VALUE + 1, Set.of()).tryToSetValue(input), is(true));
+	}
+
+	/** @see #testAccepts_agreesWithTryToSetValue_onWhatItTakes(String) */
+	@ParameterizedTest
+	@ValueSource(strings = { "", "  ", "abc", "1.5", "2147483648", "-2147483649", "99999999999", "1,000", "4 2" })
+	void testAccepts_agreesWithTryToSetValue_onWhatItRejects(String input) {
+		assertThat(SingleIntegerValue.accepts(input), is(false));
+		assertThat(new SingleIntegerValue("k").tryToSetValue(input), is(false));
+	}
+
+	@Test
+	void testAccepts_null() {
+		assertThat(SingleIntegerValue.accepts(null), is(false));
 	}
 
 	@Test

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -45,15 +45,13 @@ public abstract class AInstanz implements IInstanz {
 
 	private BiMap<String, String> _singleFloatKeyValueMap;
 
+	// the only constructor, and it takes the key alone: a parent set here would be
+	// set past IInstanzService, so neither would ChangePropagationListener pull the
+	// other side along nor would a delta be written. Use
+	// IInstanzService.createInstanz(parentKey, Type), or setParentKey below.
+	// See https://github.com/Tobias-Bonsack/Tonsias/issues/65
 	public AInstanz(String key) {
 		this._ownKey = key;
-	}
-
-	// unreachable too: Instanz is the only subclass and passes on the key alone.
-	// See https://github.com/Tobias-Bonsack/Tonsias/issues/65
-	public AInstanz(String key, String parent) {
-		this._ownKey = key;
-		this._parentKey = parent;
 	}
 
 	@Override

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleFloatValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleFloatValue.java
@@ -7,13 +7,8 @@ import de.tonsias.basis.model.enums.SingleValueType;
 
 public class SingleFloatValue extends ASingleValue<Float> {
 
-	/**
-	 * The decimal notation this type accepts as text, shared with the dialog that
-	 * greys out its OK button on anything else.
-	 */
-	public static final String DECIMAL_PATTERN = "-?\\d+(\\.\\d+)?";
-
-	private static final Pattern DECIMAL = Pattern.compile(DECIMAL_PATTERN);
+	/** the decimal notation this type accepts as text - see {@link #accepts} */
+	private static final Pattern DECIMAL = Pattern.compile("-?\\d+(\\.\\d+)?");
 
 	public SingleFloatValue(String key) {
 		super(key);
@@ -25,20 +20,32 @@ public class SingleFloatValue extends ASingleValue<Float> {
 	}
 
 	/**
-	 * Only decimal notation is accepted - {@link Float#parseFloat} would also read
-	 * "NaN", "Infinity", "1e5", "3f" and "0x1p3", none of which anybody types into
-	 * a value field on purpose. They are rejected instead of being folded into a
-	 * surprising number.
+	 * Whether this type would read the text as a number. Only decimal notation is
+	 * accepted - {@link Float#parseFloat} would also read "NaN", "Infinity", "1e5",
+	 * "3f" and "0x1p3", none of which anybody types into a value field on purpose -
+	 * and only what stays a finite number: a one followed by forty zeros passes the
+	 * notation but parses to {@code Infinity}, which is the surprising number this
+	 * type promises not to store. The dialog asks the same question for its OK
+	 * button, so there is no second rule that could drift.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
 	 */
+	public static boolean accepts(String value) {
+		if (value == null) {
+			return false;
+		}
+		String trimmed = value.strip();
+		return DECIMAL.matcher(trimmed).matches() && Float.isFinite(Float.parseFloat(trimmed));
+	}
+
 	@Override
 	public boolean tryToSetValue(Object value) {
 		if (value instanceof Float f) {
-			return setValue(f);
-		} else if (value instanceof String s) {
-			String trimmed = s.strip();
-			if (DECIMAL.matcher(trimmed).matches()) {
-				return setValue(Float.valueOf(trimmed));
-			}
+			// the same rule as for text: what the type will not read, it will not store
+			// from a caller that already holds the float either
+			return Float.isFinite(f) && setValue(f);
+		} else if (value instanceof String s && accepts(s)) {
+			return setValue(Float.valueOf(s.strip()));
 		}
 		return false;
 	}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleIntegerValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleIntegerValue.java
@@ -15,17 +15,33 @@ public class SingleIntegerValue extends ASingleValue<Integer> {
 		super(key, value, connectedInstanzes);
 	}
 
+	/**
+	 * Whether this type would read the text as a number, which is exactly what
+	 * {@link Integer#valueOf} takes: digits with an optional sign, and nothing
+	 * outside the {@code int} range. The dialog asks the same question for its OK
+	 * button, so there is no second rule that could drift - a matter of "99999999999"
+	 * being offered and then silently landing as 0.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
+	 */
+	public static boolean accepts(String value) {
+		if (value == null) {
+			return false;
+		}
+		try {
+			Integer.valueOf(value);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
 	@Override
 	public boolean tryToSetValue(Object value) {
 		if (value instanceof Integer i) {
 			return setValue(i);
-		} else if (value instanceof String s) {
-			try {
-				Integer i = Integer.valueOf(s);
-				return setValue(i);
-			} catch (NumberFormatException e) {
-				return false;
-			}
+		} else if (value instanceof String s && accepts(s)) {
+			return setValue(Integer.valueOf(s));
 		}
 		return false;
 	}

--- a/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: de.tonsias.basis.ui;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",
- junit-jupiter-params;bundle-version="5.11.1"
+ junit-jupiter-params;bundle-version="5.11.1",
+ com.google.guava;bundle-version="33.1.0"
 Import-Package: org.osgi.framework
 Automatic-Module-Name: de.tonsias.basis.ui.test
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
 import de.tonsias.basis.osgi.test.ProductRuntime;
@@ -49,6 +50,12 @@ import de.tonsias.basis.ui.i18n.Messages;
  * new value offered OK over an empty field and created a value silently left at
  * the start value of its type. See
  * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/62">#62</a>.
+ * </p>
+ * <p>
+ * The name is part of the same promise: the button is on offer when the name is
+ * free <em>and</em> the value acceptable. Each check used to set the button from
+ * its own result alone, so whichever field was touched last had the last word -
+ * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>.
  * </p>
  */
 public class ValueDialogSystemTest {
@@ -166,7 +173,7 @@ public class ValueDialogSystemTest {
 	 */
 	@ParameterizedTest
 	@ValueSource(strings = { "", " ", "3.14", "-3.14", "42", "0.0", "3,14", "NaN", "Infinity", "1e5", "3f", "0x1p3",
-			".", "-", "1.2.3" })
+			".", "-", "1.2.3", "10000000000000000000000000000000000000000" })
 	void testValueControl_floatOkFollowsWhatTheModelWouldTake(String typed) {
 		FloatValueDialog dialog = built(new FloatValueDialog(_shell, _instanz, _messages));
 
@@ -176,20 +183,107 @@ public class ValueDialogSystemTest {
 	}
 
 	/**
-	 * The inputs leave out a leading plus and numbers outside the {@code int}
-	 * range, where the dialog's pattern and {@code Integer.valueOf} disagree to
-	 * this day - that is
-	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>, not
-	 * what this test is about.
+	 * A leading plus and numbers outside the {@code int} range are in the list: the
+	 * dialog used to answer them from a pattern of its own, which took
+	 * "99999999999" that {@code Integer.valueOf} then threw on, and refused "+5"
+	 * that it would have read.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>
 	 */
 	@ParameterizedTest
-	@ValueSource(strings = { "", " ", "42", "-42", "0", "3.14", "abc", "1,000", "-", "4 2" })
+	@ValueSource(strings = { "", " ", "42", "-42", "0", "3.14", "abc", "1,000", "-", "4 2", "+5", "99999999999",
+			"2147483647", "2147483648" })
 	void testValueControl_integerOkFollowsWhatTheModelWouldTake(String typed) {
 		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
 
 		valueText(dialog).setText(typed);
 
 		assertThat("OK for '" + typed + "'", okButton(dialog).isEnabled(), is(integerTakes(typed)));
+	}
+
+	// ---------- name and value are judged together ----------
+
+	/**
+	 * A name another value of the same type already carries is not free - the
+	 * {@code BiMap} on the instanz holds names unique, so a second value under it
+	 * would push the first one out. Typing a perfectly good value afterwards must
+	 * not hand OK back; the two checks used to overwrite each other's verdict.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>
+	 */
+	@Test
+	void testNameControl_usedNameDisablesOk_andTheValueFieldDoesNotHandItBack() {
+		ProductRuntime.singleValueService().createNew(SingleIntegerValue.class, _instanz.getOwnKey(), "taken name", "1",
+				Type.SEND);
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
+
+		nameText(dialog).setText("taken name");
+		assertThat("a used name", okButton(dialog).isEnabled(), is(false));
+
+		valueText(dialog).setText("42");
+		assertThat("a number does not make the name free", okButton(dialog).isEnabled(), is(false));
+	}
+
+	/**
+	 * The other way round: a value the model would discard stays discarded while
+	 * the name is typed.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>
+	 */
+	@Test
+	void testValueControl_rejectedValueDisablesOk_andTheNameFieldDoesNotHandItBack() {
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
+
+		valueText(dialog).setText("abc");
+		assertThat("not a number", okButton(dialog).isEnabled(), is(false));
+
+		nameText(dialog).setText("a free name");
+		assertThat("a free name does not make 'abc' a number", okButton(dialog).isEnabled(), is(false));
+	}
+
+	/** Both sides content is the one case OK is on offer for. */
+	@Test
+	void testNameAndValueControl_bothAcceptable_okIsEnabled() {
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
+
+		nameText(dialog).setText("a free name");
+		valueText(dialog).setText("42");
+
+		assertThat(okButton(dialog).isEnabled(), is(true));
+	}
+
+	/**
+	 * The name in the field of an existing value is that value's own, so it may not
+	 * count as taken against itself - the dialog would open on a name it refuses.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>
+	 */
+	@Test
+	void testNameControl_existingValueKeepsItsOwnName() {
+		SingleStringValue value = ProductRuntime.singleValueService().createNew(SingleStringValue.class,
+				_instanz.getOwnKey(), "own name", "text", Type.SEND);
+
+		StringValueDialog dialog = built(new StringValueDialog(_shell, value, _instanz, _messages));
+
+		assertThat(nameText(dialog).getText(), is("own name"));
+		assertThat("untouched", okButton(dialog).isEnabled(), is(true));
+
+		nameText(dialog).setText("own name");
+		assertThat("typed again", okButton(dialog).isEnabled(), is(true));
+	}
+
+	/** The name of another value is taken for an existing value too. */
+	@Test
+	void testNameControl_existingValueTakingAnotherName() {
+		ProductRuntime.singleValueService().createNew(SingleStringValue.class, _instanz.getOwnKey(), "neighbour",
+				"text", Type.SEND);
+		SingleStringValue value = ProductRuntime.singleValueService().createNew(SingleStringValue.class,
+				_instanz.getOwnKey(), "own name", "text", Type.SEND);
+
+		StringValueDialog dialog = built(new StringValueDialog(_shell, value, _instanz, _messages));
+		nameText(dialog).setText("neighbour");
+
+		assertThat(okButton(dialog).isEnabled(), is(false));
 	}
 
 	// ---------- what the model would do ----------
@@ -243,11 +337,20 @@ public class ValueDialogSystemTest {
 	 * the test onto the wrong widget.
 	 */
 	private Text valueText(Dialog dialog) {
+		return texts(dialog).get(2);
+	}
+
+	/** the name field, the second of the three - see {@link #valueText(Dialog)} */
+	private Text nameText(Dialog dialog) {
+		return texts(dialog).get(1);
+	}
+
+	private List<Text> texts(Dialog dialog) {
 		List<Text> texts = controls(dialog.getShell()).stream()//
 				.filter(Text.class::isInstance).map(Text.class::cast)//
 				.toList();
 		assertThat("key, name and value", texts, hasSize(3));
-		return texts.get(2);
+		return texts;
 	}
 
 	/** every control below {@code root}, in the order the dialog created them */

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
@@ -1,7 +1,9 @@
 package de.tonsias.basis.ui.test.system;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
@@ -10,10 +12,13 @@ import java.util.Set;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -24,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
@@ -56,6 +63,14 @@ import de.tonsias.basis.ui.i18n.Messages;
  * free <em>and</em> the value acceptable. Each check used to set the button from
  * its own result alone, so whichever field was touched last had the last word -
  * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>.
+ * </p>
+ * <p>
+ * The rest is what the dialog says and does: the reason a name is refused, on a
+ * widget that shows it (<a href=
+ * "https://github.com/Tobias-Bonsack/Tonsias/issues/71">#71</a>), and what
+ * pressing OK leaves behind - for a stored value that used to be the name alone,
+ * with the value in the field read for the button and then dropped (<a href=
+ * "https://github.com/Tobias-Bonsack/Tonsias/issues/72">#72</a>).
  * </p>
  */
 public class ValueDialogSystemTest {
@@ -286,6 +301,92 @@ public class ValueDialogSystemTest {
 		assertThat(okButton(dialog).isEnabled(), is(false));
 	}
 
+	/**
+	 * The button is only half the answer - the dialog also has to say why. The
+	 * reason used to go to {@code Text.setMessage}, the placeholder SWT draws over
+	 * an empty field, so it was never on screen in the one case it was set for.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/71">#71</a>
+	 */
+	@Test
+	void testNameControl_usedNameIsSaidInSoManyWords() {
+		ProductRuntime.singleValueService().createNew(SingleIntegerValue.class, _instanz.getOwnKey(), "taken name", "1",
+				Type.SEND);
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
+
+		assertThat("nothing to say about a free name", nameMessage(dialog).getText(), is(""));
+
+		nameText(dialog).setText("taken name");
+		assertThat(nameMessage(dialog).getText(), is(_messages.dialog_value_usedName));
+
+		nameText(dialog).setText("a free name");
+		assertThat("taken back", nameMessage(dialog).getText(), is(""));
+	}
+
+	// ---------- what pressing OK leaves behind ----------
+
+	/**
+	 * A dialog opened on a stored value used to hand on the name alone: the number
+	 * in the field was read for the OK button and then dropped, and the dialog
+	 * closed as if it had done something.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/72">#72</a>
+	 */
+	@Test
+	void testOkPressed_existingIntegerValue_writesTheValueBack() {
+		SingleIntegerValue value = ProductRuntime.singleValueService().createNew(SingleIntegerValue.class,
+				_instanz.getOwnKey(), "count", "1", Type.SEND);
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, value, _instanz, _messages));
+
+		valueText(dialog).setText("99");
+		press(okButton(dialog));
+
+		assertThat(value.getValue(), is(99));
+	}
+
+	/** the same for the check box, which is read differently */
+	@Test
+	void testOkPressed_existingBooleanValue_writesTheCheckBoxBack() {
+		SingleBooleanValue value = ProductRuntime.singleValueService().createNew(SingleBooleanValue.class,
+				_instanz.getOwnKey(), "flag", Boolean.FALSE, Type.SEND);
+		BooleanValueDialog dialog = built(new BooleanValueDialog(_shell, value, _instanz, _messages));
+
+		checkBox(dialog).setSelection(true);
+		press(okButton(dialog));
+
+		assertThat(value.getValue(), is(true));
+	}
+
+	/** and the name, which is what the else branch did do all along */
+	@Test
+	void testOkPressed_existingValue_writesTheNameBack() {
+		SingleIntegerValue value = ProductRuntime.singleValueService().createNew(SingleIntegerValue.class,
+				_instanz.getOwnKey(), "count", "1", Type.SEND);
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, value, _instanz, _messages));
+
+		nameText(dialog).setText("counter");
+		press(okButton(dialog));
+
+		assertThat(_instanz.getSingleValues(SingleValueType.SINGLE_INTEGER).get(value.getOwnKey()), is("counter"));
+	}
+
+	/**
+	 * A new value is still created from both fields. The name travels to the
+	 * instanz on a posted event, which is {@code ChangePropagationListener}'s and
+	 * has its own tests - what is asserted here is what the dialog itself left.
+	 */
+	@Test
+	void testOkPressed_newValue_createsItFromBothFields() {
+		IntegerValueDialog dialog = built(new IntegerValueDialog(_shell, _instanz, _messages));
+
+		nameText(dialog).setText("fresh");
+		valueText(dialog).setText("7");
+		press(okButton(dialog));
+
+		assertThat(dialog.getSingleValue().getValue(), is(7));
+		assertThat(dialog.getSingleValue().getConnectedInstanzKeys(), contains(_instanz.getOwnKey()));
+	}
+
 	// ---------- what the model would do ----------
 
 	/**
@@ -343,6 +444,34 @@ public class ValueDialogSystemTest {
 	/** the name field, the second of the three - see {@link #valueText(Dialog)} */
 	private Text nameText(Dialog dialog) {
 		return texts(dialog).get(1);
+	}
+
+	/**
+	 * The label carrying the reason a name is refused. The dialog creates it right
+	 * after the name field, so it is the next control in creation order.
+	 */
+	private Label nameMessage(Dialog dialog) {
+		List<Control> all = controls(dialog.getShell());
+		Control next = all.get(all.indexOf(nameText(dialog)) + 1);
+		assertThat("the label after the name field", next, instanceOf(Label.class));
+		return (Label) next;
+	}
+
+	/** the check box a {@link BooleanValueDialog} enters its value with */
+	private Button checkBox(Dialog dialog) {
+		return controls(dialog.getShell()).stream()//
+				.filter(Button.class::isInstance).map(Button.class::cast)//
+				.filter(button -> (button.getStyle() & SWT.CHECK) != 0)//
+				.findFirst()//
+				.orElseThrow(() -> new AssertionError("no check box in " + dialog.getClass().getSimpleName()));
+	}
+
+	/**
+	 * Presses a button the way a click does - JFace turns the selection into
+	 * {@code buttonPressed(id)} and, for OK, into {@code okPressed()}.
+	 */
+	private void press(Button button) {
+		button.notifyListeners(SWT.Selection, new Event());
 	}
 
 	private List<Text> texts(Dialog dialog) {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
@@ -19,8 +19,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
-import com.google.common.collect.BiMap;
-
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -119,24 +117,38 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 	 * Whether the value control currently holds something the type's
 	 * {@code tryToSetValue} would take. The base answer is yes - a text field of any
 	 * content is a string, and a check box cannot hold an invalid state; the numeric
-	 * dialogs answer with their pattern.
+	 * dialogs put the question to their type.
 	 */
 	protected boolean isValueAcceptable() {
 		return true;
 	}
 
 	/**
-	 * Puts the OK button into the state {@link #isValueAcceptable()} calls for.
-	 * Runs once the button bar exists and again from whatever listener the subclass
-	 * puts on its value control, so an untouched field is judged by the same rule as
-	 * a typed one. Before this, a dialog opened for a new value offered OK over the
-	 * empty field its own validation rejects, and pressing it created a value silently
-	 * left at the start value of its type.
+	 * Whether the name field holds a name that is free on this instanz. Names are
+	 * the inverse side of the {@code BiMap} in {@link IInstanz}, so a second value
+	 * of the same type under the same name would push the first one out of it. The
+	 * name a stored value already carries stays acceptable - it belongs to the value
+	 * being edited, and the dialog opens with it in the field.
+	 */
+	protected boolean isNameAcceptable() {
+		String owner = _instanz.getSingleValues(_type).inverse().get(_nameText.getText());
+		return owner == null || owner.equals(_value.map(v -> v.getOwnKey()).orElse(null));
+	}
+
+	/**
+	 * Puts the OK button into the state the dialog as a whole calls for: both
+	 * {@link #isNameAcceptable()} and {@link #isValueAcceptable()} have to be
+	 * content with what stands in the fields. Runs once the button bar exists and
+	 * again from the name listener and from whatever listener the subclass puts on
+	 * its value control, so an untouched field is judged by the same rule as a typed
+	 * one, and neither of the two checks can hand the button back for input the
+	 * other has just rejected.
 	 *
 	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/62">#62</a>
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/67">#67</a>
 	 */
 	protected void refreshOkButton() {
-		getButton(IDialogConstants.OK_ID).setEnabled(isValueAcceptable());
+		getButton(IDialogConstants.OK_ID).setEnabled(isNameAcceptable() && isValueAcceptable());
 	}
 
 	private void createInstanzPart(Composite composite) {
@@ -156,20 +168,17 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 		String name = _instanz.getSingleValues(_type).getOrDefault(keyString, "");
 		_nameText = TextFactory.newText(SWT.SEARCH).text(name).enabled(true).create(composite);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(_nameText);
-		// this listener still sets the OK button from the name alone, and
-		// refreshOkButton from the value alone, so the later of the two overrides the
-		// other's verdict. See https://github.com/Tobias-Bonsack/Tonsias/issues/67
+		// the listener marks the field and leaves the button to refreshOkButton, which
+		// is the one place that knows about both checks
 		_nameText.addModifyListener(modifyEvent -> {
-			BiMap<String, String> biMap = _instanz.getSingleValues(_type);
-			if (biMap.inverse().containsKey(_nameText.getText())) {
-				_nameText.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-				_nameText.setMessage(_messages.dialog_value_usedName);
-				getButton(IDialogConstants.OK_ID).setEnabled(false);
-			} else {
+			if (isNameAcceptable()) {
 				_nameText.setBackground(null);
 				_nameText.setMessage("");
-				getButton(IDialogConstants.OK_ID).setEnabled(true);
+			} else {
+				_nameText.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
+				_nameText.setMessage(_messages.dialog_value_usedName);
 			}
+			refreshOkButton();
 		});
 	}
 

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
@@ -41,6 +41,10 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 
 	IInstanzService _iService = OsgiUtil.getService(IInstanzService.class);
 
+	// empty while a new value is being created, and then set by okPressed. Present
+	// means an existing value is being edited - which today only the tests do, and
+	// where okPressed writes the name back but not the value. See
+	// https://github.com/Tobias-Bonsack/Tonsias/issues/72
 	Optional<T> _value;
 
 	IInstanz _instanz;
@@ -176,6 +180,9 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 				_nameText.setMessage("");
 			} else {
 				_nameText.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
+				// the red field is all the user sees: setMessage is the placeholder of the
+				// field and SWT shows it only while the field is empty, which is never the
+				// case here. See https://github.com/Tobias-Bonsack/Tonsias/issues/71
 				_nameText.setMessage(_messages.dialog_value_usedName);
 			}
 			refreshOkButton();

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
@@ -42,10 +42,9 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 
 	IInstanzService _iService = OsgiUtil.getService(IInstanzService.class);
 
-	// empty while a new value is being created, and then set by okPressed. Present
-	// means an existing value is being edited - which today only the tests do, and
-	// where okPressed writes the name back but not the value. See
-	// https://github.com/Tobias-Bonsack/Tonsias/issues/72
+	// empty while a new value is being created, and set by okPressed once it is.
+	// Present means an existing value is being edited - a path ModelView does not
+	// open today, it only ever creates, so the tests are the only ones on it
 	Optional<T> _value;
 
 	IInstanz _instanz;

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/AValueDialog.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Text;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.model.interfaces.ISingleValue;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.osgi.intf.IInstanzService;
 import de.tonsias.basis.osgi.intf.IKeyService;
 import de.tonsias.basis.osgi.intf.ISingleValueService;
@@ -50,6 +51,8 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 	IInstanz _instanz;
 
 	Text _nameText;
+
+	Label _nameMessage;
 
 	C _valueControl;
 
@@ -172,21 +175,34 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 		String name = _instanz.getSingleValues(_type).getOrDefault(keyString, "");
 		_nameText = TextFactory.newText(SWT.SEARCH).text(name).enabled(true).create(composite);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(_nameText);
+
+		// the reason the OK button is off, on a widget that shows it while there is
+		// text in the field. Text.setMessage used to carry it, which is the placeholder
+		// SWT only draws over an empty field - so it was never on screen in the one
+		// case it was set for. See https://github.com/Tobias-Bonsack/Tonsias/issues/71
+		_nameMessage = LabelFactory.newLabel(SWT.None).text("").create(composite);
+		_nameMessage.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
+		GridDataFactory.fillDefaults().span(2, 1).grab(true, false).applyTo(_nameMessage);
+
 		// the listener marks the field and leaves the button to refreshOkButton, which
 		// is the one place that knows about both checks
 		_nameText.addModifyListener(modifyEvent -> {
-			if (isNameAcceptable()) {
-				_nameText.setBackground(null);
-				_nameText.setMessage("");
-			} else {
-				_nameText.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_RED));
-				// the red field is all the user sees: setMessage is the placeholder of the
-				// field and SWT shows it only while the field is empty, which is never the
-				// case here. See https://github.com/Tobias-Bonsack/Tonsias/issues/71
-				_nameText.setMessage(_messages.dialog_value_usedName);
-			}
+			refreshNameMessage();
 			refreshOkButton();
 		});
+		refreshNameMessage();
+	}
+
+	/**
+	 * Says why the name is refused, and marks the field, for whatever stands in it -
+	 * called for the name a dialog opens with as well, so an untouched field is
+	 * judged like a typed one. Leaves the OK button alone: that one is
+	 * {@link #refreshOkButton()}'s, which knows about the value too.
+	 */
+	private void refreshNameMessage() {
+		boolean acceptable = isNameAcceptable();
+		_nameText.setBackground(acceptable ? null : Display.getCurrent().getSystemColor(SWT.COLOR_RED));
+		_nameMessage.setText(acceptable ? "" : _messages.dialog_value_usedName);
 	}
 
 	private void createSingleValuePart(Composite composite) {
@@ -206,6 +222,46 @@ public abstract class AValueDialog<T extends ISingleValue<?>, C extends Control>
 	 * and prefills it from {@code valueString}, which is empty for a new value.
 	 */
 	protected abstract C createValueControl(Composite composite, String valueString);
+
+	/**
+	 * What stands in the value control, in the shape {@code tryToSetValue} takes it:
+	 * the text for the ones typed into, the check state for the boolean one.
+	 */
+	protected abstract Object getEnteredValue();
+
+	/**
+	 * The type this dialog edits, as the class {@code createNew} is handed. It is
+	 * the one in {@link #getType()}, typed, so what comes back fits {@code _value}.
+	 */
+	protected abstract Class<T> getValueClass();
+
+	/**
+	 * Creates the value, or writes back both halves of the one being edited. The
+	 * else branch used to pass on the name alone, so a changed number in the field
+	 * was read for the OK button and then dropped. Both services answer
+	 * {@code false} and fire nothing when nothing changed, so a pure rename stays
+	 * one.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/72">#72</a>
+	 */
+	@Override
+	protected void okPressed() {
+		if (_value.isEmpty()) {
+			_value = Optional.of(//
+					_sVService.createNew(getValueClass(), //
+							_instanz.getOwnKey(), //
+							_nameText.getText(), //
+							getEnteredValue(), //
+							IEventBrokerBridge.Type.POST//
+					));
+		} else {
+			String ownKey = _value.get().getOwnKey();
+			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, ownKey, _nameText.getText(),
+					IEventBrokerBridge.Type.POST);
+			_sVService.changeValue(ownKey, getEnteredValue(), IEventBrokerBridge.Type.POST);
+		}
+		super.okPressed();
+	}
 
 	public T getSingleValue() {
 		return _value.get();

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/BooleanValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/BooleanValueDialog.java
@@ -1,7 +1,5 @@
 package de.tonsias.basis.ui.dialog;
 
-import java.util.Optional;
-
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.widgets.ButtonFactory;
 import org.eclipse.swt.SWT;
@@ -12,7 +10,6 @@ import org.eclipse.swt.widgets.Shell;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
-import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
 public class BooleanValueDialog extends AValueDialog<SingleBooleanValue, Button> {
@@ -41,20 +38,13 @@ public class BooleanValueDialog extends AValueDialog<SingleBooleanValue, Button>
 	}
 
 	@Override
-	protected void okPressed() {
-		if (_value.isEmpty()) {
-			_value = Optional.of(//
-					_sVService.createNew(SingleBooleanValue.class, //
-							_instanz.getOwnKey(), //
-							_nameText.getText(), //
-							_valueControl.getSelection(), //
-							IEventBrokerBridge.Type.POST//
-					));
-		} else {
-			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
-					IEventBrokerBridge.Type.POST);
-		}
-		super.okPressed();
+	protected Object getEnteredValue() {
+		return _valueControl.getSelection();
+	}
+
+	@Override
+	protected Class<SingleBooleanValue> getValueClass() {
+		return SingleBooleanValue.class;
 	}
 
 	@Override

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
@@ -59,13 +59,13 @@ public class FloatValueDialog extends AValueDialog<SingleFloatValue, Text> {
 	}
 
 	/**
-	 * The rule {@link SingleFloatValue#tryToSetValue} applies, stripped the same
-	 * way, so the button is disabled for exactly the input that would be discarded -
-	 * the empty field a new value opens on included.
+	 * The rule of the type itself, asked rather than restated, so the button cannot
+	 * offer what {@link SingleFloatValue#tryToSetValue} would then discard - the
+	 * empty field a new value opens on included.
 	 */
 	@Override
 	protected boolean isValueAcceptable() {
-		return _valueControl.getText().strip().matches(SingleFloatValue.DECIMAL_PATTERN);
+		return SingleFloatValue.accepts(_valueControl.getText());
 	}
 
 	@Override

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/FloatValueDialog.java
@@ -1,7 +1,5 @@
 package de.tonsias.basis.ui.dialog;
 
-import java.util.Optional;
-
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.widgets.TextFactory;
 import org.eclipse.swt.SWT;
@@ -13,7 +11,6 @@ import org.eclipse.swt.widgets.Text;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
-import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
 public class FloatValueDialog extends AValueDialog<SingleFloatValue, Text> {
@@ -42,20 +39,13 @@ public class FloatValueDialog extends AValueDialog<SingleFloatValue, Text> {
 	}
 
 	@Override
-	protected void okPressed() {
-		if (_value.isEmpty()) {
-			_value = Optional.of(//
-					_sVService.createNew(SingleFloatValue.class, //
-							_instanz.getOwnKey(), //
-							_nameText.getText(), //
-							_valueControl.getText(), //
-							IEventBrokerBridge.Type.POST//
-					));
-		} else {
-			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
-					IEventBrokerBridge.Type.POST);
-		}
-		super.okPressed();
+	protected Object getEnteredValue() {
+		return _valueControl.getText();
+	}
+
+	@Override
+	protected Class<SingleFloatValue> getValueClass() {
+		return SingleFloatValue.class;
 	}
 
 	/**

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
@@ -1,7 +1,5 @@
 package de.tonsias.basis.ui.dialog;
 
-import java.util.Optional;
-
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.widgets.TextFactory;
 import org.eclipse.swt.SWT;
@@ -13,7 +11,6 @@ import org.eclipse.swt.widgets.Text;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
-import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
 public class IntegerValueDialog extends AValueDialog<SingleIntegerValue, Text> {
@@ -42,20 +39,13 @@ public class IntegerValueDialog extends AValueDialog<SingleIntegerValue, Text> {
 	}
 
 	@Override
-	protected void okPressed() {
-		if (_value.isEmpty()) {
-			_value = Optional.of(//
-					_sVService.createNew(SingleIntegerValue.class, //
-							_instanz.getOwnKey(), //
-							_nameText.getText(), //
-							_valueControl.getText(), //
-							IEventBrokerBridge.Type.POST//
-					));
-		} else {
-			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
-					IEventBrokerBridge.Type.POST);
-		}
-		super.okPressed();
+	protected Object getEnteredValue() {
+		return _valueControl.getText();
+	}
+
+	@Override
+	protected Class<SingleIntegerValue> getValueClass() {
+		return SingleIntegerValue.class;
 	}
 
 	/**

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/IntegerValueDialog.java
@@ -59,18 +59,13 @@ public class IntegerValueDialog extends AValueDialog<SingleIntegerValue, Text> {
 	}
 
 	/**
-	 * Digits with an optional minus, which is what
-	 * {@link SingleIntegerValue#tryToSetValue} takes - the empty field a new value
-	 * opens on is therefore rejected too, rather than being created as a silent 0.
-	 * <p>
-	 * The pattern and {@code Integer.valueOf} do not agree on every input; a leading
-	 * plus and numbers outside the {@code int} range are
-	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/68">#68</a>.
-	 * </p>
+	 * The rule of the type itself, asked rather than restated, so the button cannot
+	 * offer what {@link SingleIntegerValue#tryToSetValue} would then discard - the
+	 * empty field a new value opens on included.
 	 */
 	@Override
 	protected boolean isValueAcceptable() {
-		return _valueControl.getText().matches("-?\\d+");
+		return SingleIntegerValue.accepts(_valueControl.getText());
 	}
 
 	@Override

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/StringValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/StringValueDialog.java
@@ -1,7 +1,5 @@
 package de.tonsias.basis.ui.dialog;
 
-import java.util.Optional;
-
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.widgets.TextFactory;
 import org.eclipse.swt.SWT;
@@ -14,7 +12,6 @@ import org.eclipse.swt.widgets.Text;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
-import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.ui.i18n.Messages;
 
 public class StringValueDialog extends AValueDialog<SingleStringValue, Text> {
@@ -28,21 +25,13 @@ public class StringValueDialog extends AValueDialog<SingleStringValue, Text> {
 	}
 
 	@Override
-	protected void okPressed() {
-		if (_value.isEmpty()) {
-			_value = Optional.of(//
-					_sVService.createNew(SingleStringValue.class, //
-							_instanz.getOwnKey(), //
-							_nameText.getText(), //
-							_valueControl.getText(), //
-							IEventBrokerBridge.Type.POST//
-					));
-		} else {
-			_iService.changeSingleValueName(_instanz.getOwnKey(), _type, _value.get().getOwnKey(), _nameText.getText(),
-					IEventBrokerBridge.Type.POST);
-		}
+	protected Object getEnteredValue() {
+		return _valueControl.getText();
+	}
 
-		super.okPressed();
+	@Override
+	protected Class<SingleStringValue> getValueClass() {
+		return SingleStringValue.class;
 	}
 
 	@Override


### PR DESCRIPTION
Fünf Issues auf einmal, weil sie dieselbe Naht betreffen: die Wertedialoge und das, was der `CHANGELOG` darüber erzählt.

## #65 — der zweite unerreichbare Konstruktor von `AInstanz`

Ersatzlos entfernt, wie #61. `AInstanz` ist abstrakt, `Instanz` ist die einzige Unterklasse und reicht nur den Key durch — der Konstruktor mit `parent` war von nirgends aufrufbar, und ein hier gesetzter Parent liefe an `IInstanzService` vorbei: keine Gegenseite, kein Delta. Der Kommentar sitzt jetzt am verbliebenen Konstruktor und nennt `createInstanz(parentKey, Type)` als den Weg.

## #68 — die Zahlenregel gehört dem Typ

`SingleIntegerValue.accepts(String)` und `SingleFloatValue.accepts(String)` sind je die eine Regel, und `tryToSetValue` wendet sie selbst an. Die Dialoge fragen sie, statt sie nachzuerzählen. Damit verschwinden die drei Fälle aus dem Issue:

- `99999999999` wird nicht mehr angeboten und dann still als `0` abgelegt,
- `+5` wird nicht mehr gesperrt, obwohl das Modell es liest,
- eine Dezimalzahl jenseits von `Float.MAX_VALUE` wird abgelehnt, statt als `Infinity` in der Datei zu landen — die Regel prüft nach dem Parsen auf `isFinite`.

`tryToSetValue(Float)` hält sich an dieselbe Regel, damit ein Aufrufer mit einem `Float` in der Hand nicht speichern kann, was aus einem Textfeld nie herauskäme. `DECIMAL_PATTERN` ist wieder privat.

## #67 — ein Urteil, zwei Prüfungen

`refreshOkButton()` verundet jetzt `isNameAcceptable()` und `isValueAcceptable()`; der Namenslistener markiert nur noch das Feld und ruft sie. Ein bereits vergebener Name wird durch eine Änderung im Wertfeld nicht mehr freigeschaltet, ein unbrauchbarer Wert nicht durch eine Änderung im Namensfeld. Ein Name gilt als frei, wenn ihn niemand hält **oder** der bearbeitete Wert ihn selbst hält — sonst öffnete ein Dialog auf einem gespeicherten Wert mit gesperrtem OK.

## #69 und #60 — der `CHANGELOG`

Der Absatz im Präsens weicht Stichpunkten, je einem pro Issue: #52, #53, #56, #57 stehen jetzt als behoben da statt als offene Mängel bzw. gar nicht, dazu die beiden Fixes dieses Branches. `Removed` bekommt den `AInstanz`-Konstruktor.

**#60 war bereits erledigt** — der Boolean-Typ steht seit a26d2e8 (`docs changelog: record the boolean value type (#60)`) unter `### Added`, das Issue wurde nur nicht geschlossen. Hier nachgeprüft, sonst nichts daran getan.

## Tests

`SingleIntegerValueTest` und `SingleFloatValueTest` stellen `accepts(..)` und `tryToSetValue` über dieselben Eingaben nebeneinander, damit eine wieder auseinanderlaufende Regel dort auffällt — inklusive `int`-Grenzen, führendem Plus, zu großer Dezimalzahl und den nicht-endlichen Floats. `ValueDialogSystemTest` nimmt die für #68 ausgesparten Eingaben auf und bekommt einen Abschnitt zu beiden Prüfungen zusammen (46 Tests, vorher 25). `.\build.ps1` ist grün.

## #71 und #72 — unterwegs gefunden, dann gleich mitbehoben

Beide kamen beim Beheben von #67 zum Vorschein, wurden erst als Issue abgelegt und auf Zuruf im selben PR erledigt:

- **#71** — der Grund, warum ein Name abgelehnt wird, ging an `Text.setMessage(..)`: den Platzhalter, den SWT nur über einem *leeren* Feld zeichnet. Genau dann gesetzt, wenn jemand etwas getippt hat, war er nie zu sehen — übrig blieb ein rotes Feld ohne ein Wort dazu. Der Grund steht jetzt auf einem Label unter dem Feld, in derselben Farbe und nach derselben Regel gesetzt, auch für den Namen, mit dem der Dialog aufgeht. Den Button rührt es nicht an, das bleibt `refreshOkButton()`.
- **#72** — `okPressed()` reichte beim Bearbeiten eines vorhandenen Wertes nur den Namen weiter. Das Wertfeld war vorgefüllt, editierbar, wurde für den OK-Button gelesen — und sein Inhalt dann fallengelassen; der Dialog schloss sich, als sei etwas passiert. Jetzt steht `changeValue(..)` neben `changeSingleValueName(..)`; beide Services melden `false` und feuern nichts, wenn sich nichts geändert hat, eine reine Umbenennung bleibt also eine. `okPressed()` wandert dabei nach `AValueDialog` — die vier Kopien unterschieden sich nur in der Klasse und darin, wie das Widget gelesen wird, das sind jetzt `getValueClass()` und `getEnteredValue()`.

Die Tests lesen die Meldung von dem Label ab, das sie zeigt, und drücken für den Rest den OK-Button so, wie ein Klick es tut. `de.tonsias.basis.ui.test` braucht dafür neu `com.google.guava` im Manifest: den Namen von der Instanz zurückzulesen fasst die `BiMap` an, die `getSingleValues` liefert.

Closes #60, closes #65, closes #67, closes #68, closes #69, closes #71, closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
