### PR TITLE
Instanzverweis: ein SingleValueType, der auf eine andere Instanz zeigt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,23 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   points at another instanz. What it stores is the target's key — the model references
   everything by key, and resolving one needs a service the model bundle deliberately
   cannot reach — so it is persisted by the same Gson as every other value, under
-  `single_value/instanz/`, and no new event topic was needed. It is created from the
-  model view and edited in the instanz view by choosing from a list of the model's
-  instanzen rather than by typing, and `IInstanzService.resolveInstanzValue` follows it
-  back to the instanz. A reference whose target has been deleted keeps its key and
-  resolves to nothing ([#74](https://github.com/Tobias-Bonsack/Tonsias/issues/74)).
+  `single_value/instanz/`. It is created from the model view, from the create-instanz
+  dialog and from the instanz view by *choosing* the target — never by typing its key —
+  and `IInstanzService.resolveInstanzValue` follows it back to the instanz.
+- The relation is held at both ends. An instanz now carries the keys of the relations
+  pointing *at* it, `ChangePropagationListener` keeps that set in step with every
+  create, repoint and delete of a relation, and deleting an instanz puts every relation
+  that named it back to pointing nowhere instead of leaving a key that resolves to
+  nothing. The attribute itself stays — it belongs to its owner, under the name that
+  owner gave it. The set travels to disk with its instanz on the new
+  `instanz/delta/referenceChange` topic
+  ([#74](https://github.com/Tobias-Bonsack/Tonsias/issues/74)).
+- The target of a relation is chosen from a **tree with a filter field** rather than
+  from a flat combo box of every instanz in the model, so a large model stays navigable
+  and searchable. The instanz view and the value column of the create-instanz dialog
+  open it as a dialog; the relation's own value dialog shows it inline
+  ([#75](https://github.com/Tobias-Bonsack/Tonsias/issues/75),
+  [#76](https://github.com/Tobias-Bonsack/Tonsias/issues/76)).
 
 ### Changed — tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   notation is accepted — `NaN`, `Infinity`, `1e5` and the German `3,14` are rejected
   instead of turning into a number nobody typed, and the dialog greys out its OK button
   on exactly that rule.
+- `SingleInstanzValue`, a fifth attribute type, and the first that is a *relation*: it
+  points at another instanz. What it stores is the target's key — the model references
+  everything by key, and resolving one needs a service the model bundle deliberately
+  cannot reach — so it is persisted by the same Gson as every other value, under
+  `single_value/instanz/`, and no new event topic was needed. It is created from the
+  model view and edited in the instanz view by choosing from a list of the model's
+  instanzen rather than by typing, and `IInstanzService.resolveInstanzValue` follows it
+  back to the instanz. A reference whose target has been deleted keeps its key and
+  resolves to nothing ([#74](https://github.com/Tobias-Bonsack/Tonsias/issues/74)).
 
 ### Changed — tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,11 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   that named it back to pointing nowhere instead of leaving a key that resolves to
   nothing. The attribute itself stays — it belongs to its owner, under the name that
   owner gave it. The set travels to disk with its instanz on the new
-  `instanz/delta/referenceChange` topic
-  ([#74](https://github.com/Tobias-Bonsack/Tonsias/issues/74)).
+  `instanz/delta/referenceChange` topic ([#74]).
 - The target of a relation is chosen from a **tree with a filter field** rather than
   from a flat combo box of every instanz in the model, so a large model stays navigable
   and searchable. The instanz view and the value column of the create-instanz dialog
-  open it as a dialog; the relation's own value dialog shows it inline
-  ([#75](https://github.com/Tobias-Bonsack/Tonsias/issues/75),
-  [#76](https://github.com/Tobias-Bonsack/Tonsias/issues/76)).
+  open it as a dialog; the relation's own value dialog shows it inline ([#75], [#76]).
 
 ### Changed — tests
 
@@ -121,6 +118,16 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
   field was prefilled, editable and read for the OK button, and its content was then
   dropped on OK. `okPressed()` moved up into `AValueDialog`, which is where the four
   dialogs only differed in how their widget is read ([#72]).
+- `ISingleValueService.changeValue(..)` and `markSingleValueAsDelete(..)` resolve the
+  value they are given the key of instead of assuming it is in the cache. Both read the
+  cache and dereferenced the result, so every value the session had not touched — after
+  a restart, every value there is — came back as a `NullPointerException` out of the
+  service. A key does not say which type it belongs to, only the folder its file lies in
+  does, so the lookup tries one type folder after the other, the same way `deleteFile`
+  already did ([#78]).
+- `ISingleValueService.resolveKey(..)` no longer remembers a failed load. It put the
+  `null` into the cache, so the key counted as asked and answered from then on and the
+  next look — in the right folder — got the same nothing back ([#79]).
 
 [#52]: https://github.com/Tobias-Bonsack/Tonsias/issues/52
 [#53]: https://github.com/Tobias-Bonsack/Tonsias/issues/53
@@ -133,6 +140,11 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 [#68]: https://github.com/Tobias-Bonsack/Tonsias/issues/68
 [#71]: https://github.com/Tobias-Bonsack/Tonsias/issues/71
 [#72]: https://github.com/Tobias-Bonsack/Tonsias/issues/72
+[#74]: https://github.com/Tobias-Bonsack/Tonsias/issues/74
+[#75]: https://github.com/Tobias-Bonsack/Tonsias/issues/75
+[#76]: https://github.com/Tobias-Bonsack/Tonsias/issues/76
+[#78]: https://github.com/Tobias-Bonsack/Tonsias/issues/78
+[#79]: https://github.com/Tobias-Bonsack/Tonsias/issues/79
 
 ## [0.1.0] - 2026-08-07
 

--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/CreateInstanzDialogLogicSystemTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/CreateInstanzDialogLogicSystemTest.java
@@ -19,6 +19,7 @@ import org.osgi.service.prefs.BackingStoreException;
 import de.tonsias.basis.logic.dialog.CreateInstanzDialogLogic;
 import de.tonsias.basis.logic.dialog.CreateInstanzDialogLogic.TableRecord;
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
@@ -149,6 +150,117 @@ public class CreateInstanzDialogLogicSystemTest {
 		logic.addNewEntry();
 
 		assertThat(input, hasSize(2));
+	}
+
+	// ---------- a row that is a relation ----------
+
+	/**
+	 * The value column is the same column for every type, and its editor is not:
+	 * for a relation it opens the tree the value dialog offers, so what the row
+	 * holds is a key rather than text somebody typed.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/75">#75</a>
+	 */
+	@Test
+	void testSetType_switchingToARelationDropsTheTypedText() {
+		var logic = newLogic();
+		TableRecord row = logic.getInput().iterator().next();
+		row.value = "typed text";
+
+		logic.setType(row, SingleValueType.SINGLE_INSTANZ);
+
+		assertThat(row.type, is(SingleValueType.SINGLE_INSTANZ));
+		assertThat(row.value, is(""));
+	}
+
+	/** and back the other way: an instanz key is no text anybody meant to write */
+	@Test
+	void testSetType_switchingAwayFromARelationDropsTheKey() {
+		var logic = newLogic();
+		TableRecord row = logic.getInput().iterator().next();
+		logic.setType(row, SingleValueType.SINGLE_INSTANZ);
+		row.value = _inse.createInstanz(ROOT, Type.SEND).getOwnKey();
+
+		logic.setType(row, SingleValueType.SINGLE_STRING);
+
+		assertThat(row.value, is(""));
+	}
+
+	/** a switch between two typed types leaves what is in the cell alone */
+	@Test
+	void testSetType_betweenTwoTypedTypesKeepsTheValue() {
+		var logic = newLogic();
+		TableRecord row = logic.getInput().iterator().next();
+		row.value = "42";
+
+		logic.setType(row, SingleValueType.SINGLE_INTEGER);
+
+		assertThat(row.value, is("42"));
+	}
+
+	/**
+	 * What the column shows. A relation stores a key, and a key is not what the
+	 * user chose - the instanz is, and it reads here as it does in the tree.
+	 */
+	@Test
+	void testValueLabel_aRelationReadsAsItsTarget() {
+		var logic = newLogic();
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		TableRecord row = logic.getInput().iterator().next();
+		logic.setType(row, SingleValueType.SINGLE_INSTANZ);
+		row.value = target.getOwnKey();
+
+		assertThat(logic.valueLabel(row), is(logic.instanzChoices().labelOf(target)));
+	}
+
+	@Test
+	void testValueLabel_aRelationPointingNowhereShowsNothing() {
+		var logic = newLogic();
+		TableRecord row = logic.getInput().iterator().next();
+		logic.setType(row, SingleValueType.SINGLE_INSTANZ);
+
+		assertThat("nothing chosen yet", logic.valueLabel(row), is(""));
+
+		row.value = "no-such-key";
+		assertThat("a target that is gone", logic.valueLabel(row), is(""));
+	}
+
+	@Test
+	void testValueLabel_everyOtherTypeReadsAsWhatIsInTheCell() {
+		var logic = newLogic();
+		TableRecord row = logic.getInput().iterator().next();
+		row.value = "content";
+
+		assertThat(logic.valueLabel(row), is("content"));
+	}
+
+	/**
+	 * The row travels into {@code createNew} unchanged, so a relation created here
+	 * has to end up pointing where the tree said - and be followable afterwards.
+	 */
+	@Test
+	void testOkPressed_createsARelationPointingAtTheChosenInstanz() {
+		var logic = newLogic();
+		IInstanz parent = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		logic.setInstanzParent(parent);
+		TableRecord row = logic.getInput().iterator().next();
+		row.parameterName = "points at";
+		logic.setType(row, SingleValueType.SINGLE_INSTANZ);
+		row.value = target.getOwnKey();
+		_recorder.clear();
+
+		logic.okPressed(_broker);
+		_recorder.awaitTopic(EventConstants.CLOSE_OPERATION);
+
+		IInstanz created = _inse.resolveKey(parent.getChildren().iterator().next()).orElseThrow();
+		String valueKey = created.getSingleValues(SingleValueType.SINGLE_INSTANZ).keySet().iterator().next();
+		SingleInstanzValue relation = _svs
+				.resolveKey(SingleValueType.SINGLE_INSTANZ.getPath(), valueKey, SingleInstanzValue.class).orElseThrow();
+
+		assertThat(relation.getValue(), is(target.getOwnKey()));
+		assertThat(_inse.resolveInstanzValue(relation), is(java.util.Optional.of(target)));
+		assertThat("and the target knows about it", target.getReferencingValueKeys(), hasItem(valueKey));
 	}
 
 	// ---------- creating the instanz ----------

--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/InstanzChoicesSystemTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/InstanzChoicesSystemTest.java
@@ -1,0 +1,164 @@
+package de.tonsias.basis.logic.test.system;
+
+import static de.tonsias.basis.osgi.test.ProductRuntime.ROOT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.logic.part.InstanzChoices;
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
+import de.tonsias.basis.osgi.test.ProductRuntime;
+
+/**
+ * The instanzen a relation can be pointed at, and how they read.
+ * <p>
+ * The runtime is shared by the whole bundle, so the tree already holds whatever
+ * the other tests left below the root. Every assertion here is therefore about
+ * the subtree this test built - what else is in the list is none of its
+ * business.
+ * </p>
+ */
+public class InstanzChoicesSystemTest {
+
+	private static final String PARAMETER = "InstanzChoicesSystemTest label";
+
+	IInstanzService _inse;
+
+	ISingleValueService _svs;
+
+	IBasicPreferenceService _prefs;
+
+	InstanzChoices _choices;
+
+	/** what the preference held before, so the shared runtime is left as found */
+	Optional<String> _previousModelViewText;
+
+	@BeforeEach
+	void beforeEach() {
+		ProductRuntime.start();
+		_inse = ProductRuntime.instanzService();
+		_svs = ProductRuntime.singleValueService();
+		_prefs = ProductRuntime.preferenceService();
+		_choices = new InstanzChoices(_inse, _svs, _prefs);
+
+		_previousModelViewText = _prefs.getValue(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(), String.class);
+	}
+
+	@AfterEach
+	void afterEach() throws Exception {
+		_prefs.saveAsToString(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(),
+				_previousModelViewText.orElse(""));
+		ProductRuntime.flushDeltas();
+	}
+
+	@Test
+	void testChoices_startAtTheRoot() {
+		assertThat(_choices.choices().get(0)._key(), is(ROOT));
+	}
+
+	/** a whole branch, so the walk has to go past the first level */
+	@Test
+	void testChoices_containTheWholeSubtree() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
+
+		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+
+		assertThat(keys, hasItem(child.getOwnKey()));
+		assertThat(keys, hasItem(grandChild.getOwnKey()));
+	}
+
+	/** depth first, the way the Model View draws it: a child before its sibling */
+	@Test
+	void testChoices_areInTreeOrder() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
+
+		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+
+		assertThat(keys.indexOf(grandChild.getOwnKey()), is(keys.indexOf(child.getOwnKey()) + 1));
+	}
+
+	/** every instanz is offered once, however often the walk meets it */
+	@Test
+	void testChoices_holdNoKeyTwice() {
+		_inse.createInstanz(ROOT, Type.SEND);
+
+		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+
+		assertThat(keys, is(keys.stream().distinct().toList()));
+	}
+
+	// ---------- how an instanz reads ----------
+
+	/**
+	 * The preference names a parameter; the instanz carrying a string value under
+	 * that name reads as its content. This is the rule the Model View labels its
+	 * nodes by, and the combo box of a relation has to agree with it.
+	 */
+	@Test
+	void testLabelOf_takesTheValueThePreferenceNames() throws Exception {
+		_prefs.saveAsToString(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(), PARAMETER);
+		IInstanz named = _inse.createInstanz(ROOT, Type.SEND);
+		_svs.createNew(SingleStringValue.class, named.getOwnKey(), PARAMETER, "Kundennummer", Type.SEND);
+
+		assertThat(_choices.labelOf(named), is("Kundennummer"));
+		assertThat(_choices.choices(), hasItem(new Choice(named.getOwnKey(), "Kundennummer")));
+	}
+
+	/** an instanz without that parameter falls back on what it says about itself */
+	@Test
+	void testLabelOf_fallsBackToToString() throws Exception {
+		_prefs.saveAsToString(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(), PARAMETER);
+		IInstanz plain = _inse.createInstanz(ROOT, Type.SEND);
+
+		assertThat(_choices.labelOf(plain), is(plain.toString()));
+	}
+
+	/** and so does every instanz while the preference names nothing at all */
+	@Test
+	void testLabelOf_fallsBackWhenThePreferenceIsUnset() throws Exception {
+		_prefs.saveAsToString(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(), "");
+		IInstanz named = _inse.createInstanz(ROOT, Type.SEND);
+		_svs.createNew(SingleStringValue.class, named.getOwnKey(), PARAMETER, "Kundennummer", Type.SEND);
+
+		assertThat(_choices.labelOf(named), is(named.toString()));
+	}
+
+	/** the label a choice carries is the one labelOf gives - one rule, not two */
+	@Test
+	void testChoices_labelEveryEntryTheWayLabelOfDoes() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+
+		Choice choice = _choices.choices().stream()//
+				.filter(c -> c._key().equals(child.getOwnKey()))//
+				.findFirst().orElseThrow();
+
+		assertThat(choice._label(), is(_choices.labelOf(child)));
+	}
+
+	/**
+	 * Nothing is filtered out: an instanz may point at itself. A relation is no
+	 * parent-child edge, so it cannot build a cycle in the tree, and there is no
+	 * reason to keep the user from expressing one.
+	 */
+	@Test
+	void testChoices_containTheInstanzItself() {
+		IInstanz self = _inse.createInstanz(ROOT, Type.SEND);
+
+		assertThat(_choices.choices().stream().map(Choice::_key).toList(), hasItem(self.getOwnKey()));
+	}
+}

--- a/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/InstanzChoicesSystemTest.java
+++ b/de.tonsias.basis.logic.test/src/de/tonsias/basis/logic/test/system/InstanzChoicesSystemTest.java
@@ -2,6 +2,7 @@ package de.tonsias.basis.logic.test.system;
 
 import static de.tonsias.basis.osgi.test.ProductRuntime.ROOT;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
@@ -27,8 +28,13 @@ import de.tonsias.basis.osgi.test.ProductRuntime;
  * <p>
  * The runtime is shared by the whole bundle, so the tree already holds whatever
  * the other tests left below the root. Every assertion here is therefore about
- * the subtree this test built - what else is in the list is none of its
+ * the subtree this test built - what else is in the model is none of its
  * business.
+ * </p>
+ * <p>
+ * The shape is a tree, not a flat list: the widget filters it and draws it as
+ * one, which is what makes a large model selectable at all, see
+ * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>.
  * </p>
  */
 public class InstanzChoicesSystemTest {
@@ -64,42 +70,87 @@ public class InstanzChoicesSystemTest {
 		ProductRuntime.flushDeltas();
 	}
 
+	private List<String> flatKeys() {
+		return _choices.tree().flatten().stream().map(Choice::_key).toList();
+	}
+
 	@Test
-	void testChoices_startAtTheRoot() {
-		assertThat(_choices.choices().get(0)._key(), is(ROOT));
+	void testTree_startsAtTheRoot() {
+		assertThat(_choices.tree()._key(), is(ROOT));
 	}
 
 	/** a whole branch, so the walk has to go past the first level */
 	@Test
-	void testChoices_containTheWholeSubtree() {
+	void testTree_containsTheWholeSubtree() {
 		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
 		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
 
-		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+		assertThat(flatKeys(), hasItem(child.getOwnKey()));
+		assertThat(flatKeys(), hasItem(grandChild.getOwnKey()));
+	}
 
-		assertThat(keys, hasItem(child.getOwnKey()));
-		assertThat(keys, hasItem(grandChild.getOwnKey()));
+	/**
+	 * The nesting itself, which is the whole reason this is a tree: a child hangs
+	 * below its parent rather than next to it.
+	 */
+	@Test
+	void testTree_hangsEveryChildBelowItsParent() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
+
+		Choice childChoice = _choices.tree().find(child.getOwnKey()).orElseThrow();
+
+		assertThat(childChoice._children().stream().map(Choice::_key).toList(), contains(grandChild.getOwnKey()));
+		assertThat("the root holds it, not the grandchild's grandparent",
+				_choices.tree()._children().stream().map(Choice::_key).toList(), hasItem(child.getOwnKey()));
 	}
 
 	/** depth first, the way the Model View draws it: a child before its sibling */
 	@Test
-	void testChoices_areInTreeOrder() {
+	void testFlatten_isInTreeOrder() {
 		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
 		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
 
-		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+		List<String> keys = flatKeys();
 
 		assertThat(keys.indexOf(grandChild.getOwnKey()), is(keys.indexOf(child.getOwnKey()) + 1));
 	}
 
 	/** every instanz is offered once, however often the walk meets it */
 	@Test
-	void testChoices_holdNoKeyTwice() {
+	void testFlatten_holdsNoKeyTwice() {
 		_inse.createInstanz(ROOT, Type.SEND);
 
-		List<String> keys = _choices.choices().stream().map(Choice::_key).toList();
+		List<String> keys = flatKeys();
 
 		assertThat(keys, is(keys.stream().distinct().toList()));
+	}
+
+	// ---------- finding one again ----------
+
+	/**
+	 * What a stored relation is shown with: it holds a key, and the tree is the one
+	 * place that says how that key reads.
+	 */
+	@Test
+	void testFind_locatesAnInstanzAnywhereInTheTree() {
+		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
+		IInstanz grandChild = _inse.createInstanz(child.getOwnKey(), Type.SEND);
+
+		assertThat(_choices.tree().find(grandChild.getOwnKey()).orElseThrow()._key(), is(grandChild.getOwnKey()));
+		assertThat(_choices.labelOf(grandChild.getOwnKey()), is(Optional.of(_choices.labelOf(grandChild))));
+	}
+
+	/**
+	 * A relation pointing nowhere holds the empty string, and one whose target was
+	 * deleted holds a key the tree no longer has. Neither is an error - both simply
+	 * name no instanz.
+	 */
+	@Test
+	void testFind_aKeyTheTreeDoesNotHoldIsEmpty() {
+		assertThat(_choices.tree().find(""), is(Optional.empty()));
+		assertThat(_choices.tree().find("no-such-key"), is(Optional.empty()));
+		assertThat(_choices.labelOf("no-such-key"), is(Optional.empty()));
 	}
 
 	// ---------- how an instanz reads ----------
@@ -107,7 +158,7 @@ public class InstanzChoicesSystemTest {
 	/**
 	 * The preference names a parameter; the instanz carrying a string value under
 	 * that name reads as its content. This is the rule the Model View labels its
-	 * nodes by, and the combo box of a relation has to agree with it.
+	 * nodes by, and the chooser of a relation has to agree with it.
 	 */
 	@Test
 	void testLabelOf_takesTheValueThePreferenceNames() throws Exception {
@@ -116,7 +167,7 @@ public class InstanzChoicesSystemTest {
 		_svs.createNew(SingleStringValue.class, named.getOwnKey(), PARAMETER, "Kundennummer", Type.SEND);
 
 		assertThat(_choices.labelOf(named), is("Kundennummer"));
-		assertThat(_choices.choices(), hasItem(new Choice(named.getOwnKey(), "Kundennummer")));
+		assertThat(_choices.tree().find(named.getOwnKey()).orElseThrow()._label(), is("Kundennummer"));
 	}
 
 	/** an instanz without that parameter falls back on what it says about itself */
@@ -140,12 +191,10 @@ public class InstanzChoicesSystemTest {
 
 	/** the label a choice carries is the one labelOf gives - one rule, not two */
 	@Test
-	void testChoices_labelEveryEntryTheWayLabelOfDoes() {
+	void testTree_labelsEveryEntryTheWayLabelOfDoes() {
 		IInstanz child = _inse.createInstanz(ROOT, Type.SEND);
 
-		Choice choice = _choices.choices().stream()//
-				.filter(c -> c._key().equals(child.getOwnKey()))//
-				.findFirst().orElseThrow();
+		Choice choice = _choices.tree().find(child.getOwnKey()).orElseThrow();
 
 		assertThat(choice._label(), is(_choices.labelOf(child)));
 	}
@@ -156,9 +205,9 @@ public class InstanzChoicesSystemTest {
 	 * reason to keep the user from expressing one.
 	 */
 	@Test
-	void testChoices_containTheInstanzItself() {
+	void testTree_containsTheInstanzItself() {
 		IInstanz self = _inse.createInstanz(ROOT, Type.SEND);
 
-		assertThat(_choices.choices().stream().map(Choice::_key).toList(), hasItem(self.getOwnKey()));
+		assertThat(flatKeys(), hasItem(self.getOwnKey()));
 	}
 }

--- a/de.tonsias.basis.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: de.tonsias.basis.osgi,
  org.eclipse.equinox.registry,
  de.tonsias.basis.model,
  org.eclipse.e4.core.services,
- org.osgi.service.event
+ org.osgi.service.event,
+ com.google.guava

--- a/de.tonsias.basis.logic/src/de/tonsias/basis/logic/dialog/CreateInstanzDialogLogic.java
+++ b/de.tonsias.basis.logic/src/de/tonsias/basis/logic/dialog/CreateInstanzDialogLogic.java
@@ -55,6 +55,13 @@ public class CreateInstanzDialogLogic {
 		return _tableInput;
 	}
 
+	/**
+	 * A row of the table, and the value in it is whatever the cell editor of the
+	 * column left there - text, for every type alike. A
+	 * {@code SingleValueType.SINGLE_INSTANZ} row therefore has to be given the raw
+	 * key of its target instead of choosing it from a list, see
+	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/75">#75</a>.
+	 */
 	public class TableRecord {
 		public SingleValueType type;
 		public String parameterName;

--- a/de.tonsias.basis.logic/src/de/tonsias/basis/logic/dialog/CreateInstanzDialogLogic.java
+++ b/de.tonsias.basis.logic/src/de/tonsias/basis/logic/dialog/CreateInstanzDialogLogic.java
@@ -9,6 +9,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 
+import de.tonsias.basis.logic.part.InstanzChoices;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
@@ -56,11 +57,11 @@ public class CreateInstanzDialogLogic {
 	}
 
 	/**
-	 * A row of the table, and the value in it is whatever the cell editor of the
-	 * column left there - text, for every type alike. A
-	 * {@code SingleValueType.SINGLE_INSTANZ} row therefore has to be given the raw
-	 * key of its target instead of choosing it from a list, see
-	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/75">#75</a>.
+	 * A row of the table: what kind of attribute, under what name, holding what.
+	 * The value is whatever the cell editor of the column left there - text for the
+	 * types that are typed into, and the key of the target for a
+	 * {@code SingleValueType.SINGLE_INSTANZ} row, which is chosen from the same
+	 * tree the value dialog offers.
 	 */
 	public class TableRecord {
 		public SingleValueType type;
@@ -73,6 +74,46 @@ public class CreateInstanzDialogLogic {
 			this.value = value;
 
 		}
+	}
+
+	/**
+	 * Changes what a row is, and drops a value the new type would not take with it.
+	 * A relation stores a key and nothing else, so text typed under another type is
+	 * no starting point for it - and the key of an instanz is no text anybody meant
+	 * to write either.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/75">#75</a>
+	 */
+	public void setType(TableRecord row, SingleValueType type) {
+		boolean wasRelation = row.type == SingleValueType.SINGLE_INSTANZ;
+		row.type = type;
+
+		if (wasRelation != (type == SingleValueType.SINGLE_INSTANZ)) {
+			row.value = "";
+		}
+	}
+
+	/**
+	 * What the value column shows for a row. A relation stores the key of its
+	 * target, which is no text to put in front of anybody - it reads as the target
+	 * does everywhere else.
+	 *
+	 * @return the label of the target, and an empty string for a relation pointing
+	 *         nowhere or at an instanz the walk did not reach
+	 */
+	public String valueLabel(TableRecord row) {
+		if (row.type != SingleValueType.SINGLE_INSTANZ) {
+			return String.valueOf(row.value);
+		}
+		return instanzChoices().labelOf(String.valueOf(row.value)).orElse("");
+	}
+
+	/**
+	 * The instanzen a relation can be pointed at. Built per call rather than kept:
+	 * the dialog stays open while the model can change under it.
+	 */
+	public InstanzChoices instanzChoices() {
+		return new InstanzChoices(_ins, _sin, _basic);
 	}
 
 	public void setInstanzParent(IInstanz iParent) {

--- a/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzChoices.java
+++ b/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzChoices.java
@@ -1,0 +1,98 @@
+package de.tonsias.basis.logic.part;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
+import de.tonsias.basis.osgi.intf.IInstanzService;
+import de.tonsias.basis.osgi.intf.ISingleValueService;
+
+/**
+ * The instanzen a relation can point at, in the order the model tree holds them,
+ * each with the label it carries in the Model View.
+ * <p>
+ * This is what a {@code SingleInstanzValue} is chosen from, and it lives here
+ * rather than next to the widget so it can be tested without SWT. The target is
+ * not filtered: a reference to the instanz itself is no parent-child edge and so
+ * cannot build a cycle in the tree.
+ * </p>
+ */
+public class InstanzChoices {
+
+	/**
+	 * @param _key   of the instanz, which is what a reference stores
+	 * @param _label how it reads in the Model View
+	 */
+	public record Choice(String _key, String _label) {
+	}
+
+	private final IInstanzService _instanzService;
+
+	private final ISingleValueService _singleValueService;
+
+	private final IBasicPreferenceService _preferenceService;
+
+	public InstanzChoices(IInstanzService instanzService, ISingleValueService singleValueService,
+			IBasicPreferenceService preferenceService) {
+		_instanzService = instanzService;
+		_singleValueService = singleValueService;
+		_preferenceService = preferenceService;
+	}
+
+	/**
+	 * Walks the tree from the root down, depth first, so the list reads like the
+	 * Model View. Children that do not resolve are skipped rather than reported -
+	 * the same thing the tree does when it builds its nodes.
+	 * <p>
+	 * Every instanz of the model, flat: a combo box is what this fills, and a large
+	 * model makes it a long one, see
+	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>.
+	 * </p>
+	 *
+	 * @return every reachable instanz, the root first
+	 */
+	public List<Choice> choices() {
+		List<Choice> result = new ArrayList<>();
+		// a child key claiming an ancestor would otherwise walk forever. The services
+		// keep parent and child in sync, but nothing stops a hand-edited file
+		collect(_instanzService.getRoot(), result, new LinkedHashSet<>());
+		return result;
+	}
+
+	private void collect(IInstanz instanz, List<Choice> result, Set<String> seen) {
+		if (instanz == null || !seen.add(instanz.getOwnKey())) {
+			return;
+		}
+		result.add(new Choice(instanz.getOwnKey(), labelOf(instanz)));
+		for (String childKey : List.copyOf(instanz.getChildren())) {
+			_instanzService.resolveKey(childKey).ifPresent(child -> collect(child, result, seen));
+		}
+	}
+
+	/**
+	 * How an instanz reads: the content of the string value the
+	 * {@code MODEL_VIEW_TEXT} preference names, and its {@code toString()} when the
+	 * preference is unset or names nothing this instanz carries. The Model View
+	 * labels its nodes by the same rule, and this is the one place it is written -
+	 * a reference that read differently there and here would be hard to follow.
+	 */
+	public String labelOf(IInstanz instanz) {
+		Optional<String> parameterName = _preferenceService
+				.getValue(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(), String.class);
+		if (parameterName.isEmpty()) {
+			return instanz.toString();
+		}
+
+		String valueKey = instanz.getSingleValues(SingleValueType.SINGLE_STRING).inverse().get(parameterName.get());
+		return _singleValueService
+				.resolveKey(SingleValueType.SINGLE_STRING.getPath(), valueKey, SingleStringValue.class)
+				.map(SingleStringValue::getValue)//
+				.orElseGet(instanz::toString);
+	}
+}

--- a/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzChoices.java
+++ b/de.tonsias.basis.logic/src/de/tonsias/basis/logic/part/InstanzChoices.java
@@ -14,22 +14,53 @@ import de.tonsias.basis.osgi.intf.IInstanzService;
 import de.tonsias.basis.osgi.intf.ISingleValueService;
 
 /**
- * The instanzen a relation can point at, in the order the model tree holds them,
- * each with the label it carries in the Model View.
+ * The instanzen a relation can point at, as the tree the model is, each with
+ * the label it carries in the Model View.
  * <p>
  * This is what a {@code SingleInstanzValue} is chosen from, and it lives here
  * rather than next to the widget so it can be tested without SWT. The target is
  * not filtered: a reference to the instanz itself is no parent-child edge and so
  * cannot build a cycle in the tree.
  * </p>
+ * <p>
+ * The shape is a tree and not a list on purpose. A flat list of every instanz is
+ * unusable as soon as a model grows, and it throws away the one thing the user
+ * navigates by - where an instanz sits. The widget adds a filter on top of it,
+ * see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>.
+ * </p>
  */
 public class InstanzChoices {
 
 	/**
-	 * @param _key   of the instanz, which is what a reference stores
-	 * @param _label how it reads in the Model View
+	 * @param _key      of the instanz, which is what a reference stores
+	 * @param _label    how it reads in the Model View
+	 * @param _children the same, for everything below it
 	 */
-	public record Choice(String _key, String _label) {
+	public record Choice(String _key, String _label, List<Choice> _children) {
+
+		/**
+		 * This choice and everything below it, depth first - the order the Model View
+		 * draws its nodes in.
+		 */
+		public List<Choice> flatten() {
+			List<Choice> result = new ArrayList<>();
+			result.add(this);
+			_children.forEach(child -> result.addAll(child.flatten()));
+			return result;
+		}
+
+		/**
+		 * @param key of the instanz to look for, the stored side of a relation
+		 * @return the choice for it, empty for a key this subtree does not hold - a
+		 *         relation pointing nowhere included, whose key is the empty string
+		 */
+		public Optional<Choice> find(String key) {
+			if (_key.equals(key)) {
+				return Optional.of(this);
+			}
+			return _children.stream().map(child -> child.find(key)).filter(Optional::isPresent).map(Optional::get)
+					.findFirst();
+		}
 	}
 
 	private final IInstanzService _instanzService;
@@ -46,33 +77,29 @@ public class InstanzChoices {
 	}
 
 	/**
-	 * Walks the tree from the root down, depth first, so the list reads like the
-	 * Model View. Children that do not resolve are skipped rather than reported -
-	 * the same thing the tree does when it builds its nodes.
-	 * <p>
-	 * Every instanz of the model, flat: a combo box is what this fills, and a large
-	 * model makes it a long one, see
-	 * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>.
-	 * </p>
+	 * Walks the tree from the root down. Children that do not resolve are skipped
+	 * rather than reported - the same thing the Model View does when it builds its
+	 * nodes.
 	 *
-	 * @return every reachable instanz, the root first
+	 * @return the root, carrying every reachable instanz below it
 	 */
-	public List<Choice> choices() {
-		List<Choice> result = new ArrayList<>();
+	public Choice tree() {
+		IInstanz root = _instanzService.getRoot();
 		// a child key claiming an ancestor would otherwise walk forever. The services
 		// keep parent and child in sync, but nothing stops a hand-edited file
-		collect(_instanzService.getRoot(), result, new LinkedHashSet<>());
-		return result;
+		Set<String> seen = new LinkedHashSet<>();
+		seen.add(root.getOwnKey());
+		return collect(root, seen);
 	}
 
-	private void collect(IInstanz instanz, List<Choice> result, Set<String> seen) {
-		if (instanz == null || !seen.add(instanz.getOwnKey())) {
-			return;
-		}
-		result.add(new Choice(instanz.getOwnKey(), labelOf(instanz)));
+	private Choice collect(IInstanz instanz, Set<String> seen) {
+		List<Choice> children = new ArrayList<>();
 		for (String childKey : List.copyOf(instanz.getChildren())) {
-			_instanzService.resolveKey(childKey).ifPresent(child -> collect(child, result, seen));
+			_instanzService.resolveKey(childKey)//
+					.filter(child -> seen.add(child.getOwnKey()))//
+					.ifPresent(child -> children.add(collect(child, seen)));
 		}
+		return new Choice(instanz.getOwnKey(), labelOf(instanz), List.copyOf(children));
 	}
 
 	/**
@@ -94,5 +121,17 @@ public class InstanzChoices {
 				.resolveKey(SingleValueType.SINGLE_STRING.getPath(), valueKey, SingleStringValue.class)
 				.map(SingleStringValue::getValue)//
 				.orElseGet(instanz::toString);
+	}
+
+	/**
+	 * How the instanz behind a stored relation reads, for the places that show
+	 * where a reference points without offering the choice again.
+	 *
+	 * @param instanzKey the stored side of a relation, empty when it points nowhere
+	 * @return the label, or an empty {@link Optional} for a key the tree does not
+	 *         hold - which is what a relation whose target was deleted would be
+	 */
+	public Optional<String> labelOf(String instanzKey) {
+		return tree().find(instanzKey).map(Choice::_label);
 	}
 }

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/impl/AInstanzTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/impl/AInstanzTest.java
@@ -157,4 +157,47 @@ public class AInstanzTest {
 		assertThat(children, contains("a"));
 		assertThat(children, is(not(empty())));
 	}
+
+	// ---------- the backward end of a relation ----------
+
+	/**
+	 * Created on demand like the value maps, and for the same reason: Gson skips
+	 * field initializers, and an instanz stored before this field existed names it
+	 * nowhere at all.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testGetReferencingValueKeys_isEmptyNotNullOnANewInstanz() {
+		assertThat(_instanz.getReferencingValueKeys(), is(empty()));
+		assertThat(_instanz.getReferencingValueKeys(), is(sameInstance(_instanz.getReferencingValueKeys())));
+	}
+
+	@Test
+	void testAddReferencingValueKey_reportsWhetherItWasNew() {
+		assertThat(_instanz.addReferencingValueKey("v1"), is(true));
+		assertThat(_instanz.addReferencingValueKey("v1"), is(false));
+		assertThat(_instanz.addReferencingValueKey("v2"), is(true));
+
+		assertThat(_instanz.getReferencingValueKeys(), containsInAnyOrder("v1", "v2"));
+	}
+
+	@Test
+	void testRemoveReferencingValueKey_reportsWhetherItWasThere() {
+		_instanz.addReferencingValueKey("v1");
+
+		assertThat(_instanz.removeReferencingValueKey("v1"), is(true));
+		assertThat(_instanz.removeReferencingValueKey("v1"), is(false));
+		assertThat(_instanz.getReferencingValueKeys(), is(empty()));
+	}
+
+	/** nothing is no value key - a relation pointing nowhere records nobody */
+	@Test
+	void testAddReferencingValueKey_blankIsRejected() {
+		assertThat(_instanz.addReferencingValueKey(null), is(false));
+		assertThat(_instanz.addReferencingValueKey(""), is(false));
+		assertThat(_instanz.addReferencingValueKey(" "), is(false));
+
+		assertThat(_instanz.getReferencingValueKeys(), is(empty()));
+	}
 }

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleInstanzValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleInstanzValueTest.java
@@ -71,12 +71,35 @@ public class SingleInstanzValueTest {
 		assertThat(new SingleInstanzValue("k", "seed", Set.of()).tryToSetValue(input), is(true));
 	}
 
-	/** @see #testAccepts_agreesWithTryToSetValue_onWhatItTakes(String) */
+	/**
+	 * @see #testAccepts_agreesWithTryToSetValue_onWhatItTakes(String)
+	 * @see #testTryToSetValue_theEmptyStringPointsNowhereAndIsTheOneDisagreement()
+	 *      for the single input the two answer differently
+	 */
 	@ParameterizedTest
-	@ValueSource(strings = { "", " ", "A", "1A", "-1", "1 2", "1.2", "a b", " 3" })
+	@ValueSource(strings = { " ", "A", "1A", "-1", "1 2", "1.2", "a b", " 3" })
 	void testAccepts_agreesWithTryToSetValue_onWhatItRejects(String input) {
 		assertThat(SingleInstanzValue.accepts(input), is(false));
 		assertThat(new SingleInstanzValue("k", "seed", Set.of()).tryToSetValue(input), is(false));
+	}
+
+	/**
+	 * The two questions come apart on exactly one input. Pointing nowhere is a
+	 * state this value has - the one a fresh one starts in - and a relation is put
+	 * back into it when its target is deleted, so {@code tryToSetValue} has to take
+	 * the empty string. {@code accepts} still refuses it, because that is what the
+	 * dialog asks: nothing chosen must not become a value.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testTryToSetValue_theEmptyStringPointsNowhereAndIsTheOneDisagreement() {
+		SingleInstanzValue value = new SingleInstanzValue("k", "seed", Set.of());
+
+		assertThat(value.tryToSetValue(""), is(true));
+		assertThat(value.getValue(), is(""));
+		assertThat("but never on offer in the dialog", SingleInstanzValue.accepts(""), is(false));
+		assertThat("and no change when it already points nowhere", value.tryToSetValue(""), is(false));
 	}
 
 	@Test

--- a/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleInstanzValueTest.java
+++ b/de.tonsias.basis.model.test/src/de/tonsias/basis/model/test/value/SingleInstanzValueTest.java
@@ -1,0 +1,107 @@
+package de.tonsias.basis.model.test.value;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
+
+public class SingleInstanzValueTest {
+
+	/**
+	 * A fresh reference points nowhere. The empty string is deliberately not a key
+	 * {@code accepts} would take, so the dialog keeps its OK button off until an
+	 * instanz has been chosen.
+	 */
+	@Test
+	void testNewValue_pointsNowhere() {
+		assertThat(new SingleInstanzValue("k").getValue(), is(""));
+		assertThat(SingleInstanzValue.accepts(new SingleInstanzValue("k").getValue()), is(false));
+	}
+
+	@Test
+	void testGetPath_matchesTheEnum() {
+		assertThat(new SingleInstanzValue("k").getPath(), is(SingleValueType.SINGLE_INSTANZ.getPath()));
+	}
+
+	/**
+	 * The value folder sits below {@code single_value/}, so it cannot meet the
+	 * {@code instanz/} folder the instanzen themselves are written into - both would
+	 * otherwise hold a file named after the same key.
+	 */
+	@Test
+	void testGetPath_doesNotCollideWithTheInstanzFolder() {
+		assertThat(SingleValueType.SINGLE_INSTANZ.getPath(), is("single_value/instanz/"));
+	}
+
+	@Test
+	void testTryToSetValue_key() {
+		SingleInstanzValue value = new SingleInstanzValue("k");
+
+		assertThat(value.tryToSetValue("3"), is(true));
+		assertThat(value.getValue(), is("3"));
+	}
+
+	@Test
+	void testTryToSetValue_sameKeyIsNoChange() {
+		SingleInstanzValue value = new SingleInstanzValue("k");
+		value.tryToSetValue("3");
+
+		assertThat(value.tryToSetValue("3"), is(false));
+	}
+
+	/**
+	 * {@code accepts} is what the dialog asks before it offers its OK button, so it
+	 * has to answer for the same input the same way {@code tryToSetValue} does.
+	 * Keys are base 36 and lower case only - upper case is out because the files are
+	 * named after them and two of them would be one file on Windows.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "0", "3", "z", "1a", "10", "zzz" })
+	void testAccepts_agreesWithTryToSetValue_onWhatItTakes(String input) {
+		assertThat(SingleInstanzValue.accepts(input), is(true));
+		// seeded away from every input, because setValue answers false for "already
+		// that value" as well
+		assertThat(new SingleInstanzValue("k", "seed", Set.of()).tryToSetValue(input), is(true));
+	}
+
+	/** @see #testAccepts_agreesWithTryToSetValue_onWhatItTakes(String) */
+	@ParameterizedTest
+	@ValueSource(strings = { "", " ", "A", "1A", "-1", "1 2", "1.2", "a b", " 3" })
+	void testAccepts_agreesWithTryToSetValue_onWhatItRejects(String input) {
+		assertThat(SingleInstanzValue.accepts(input), is(false));
+		assertThat(new SingleInstanzValue("k", "seed", Set.of()).tryToSetValue(input), is(false));
+	}
+
+	@Test
+	void testAccepts_null() {
+		assertThat(SingleInstanzValue.accepts(null), is(false));
+	}
+
+	/**
+	 * Anything that is not text is not a key either - the value travels from the
+	 * widget as a {@link String} and from nowhere else.
+	 */
+	@Test
+	void testTryToSetValue_nonTextIsRejected() {
+		SingleInstanzValue value = new SingleInstanzValue("k", "seed", Set.of());
+
+		assertThat("a number is no key", value.tryToSetValue(3), is(false));
+		assertThat("nothing is no key", value.tryToSetValue(null), is(false));
+		assertThat(value.getValue(), is("seed"));
+	}
+
+	@Test
+	void testToString_containsKeyValueAndSimpleClassName() {
+		SingleInstanzValue value = new SingleInstanzValue("k");
+		value.tryToSetValue("3");
+
+		assertThat(value.toString(), is("k 3 : SingleInstanzValue"));
+	}
+}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/enums/SingleValueType.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -16,7 +17,11 @@ public enum SingleValueType {
 	SINGLE_STRING(SingleStringValue.class, "single_value/string/"),
 	SINGLE_INTEGER(SingleIntegerValue.class, "single_value/integer/"),
 	SINGLE_BOOLEAN(SingleBooleanValue.class, "single_value/boolean/"),
-	SINGLE_FLOAT(SingleFloatValue.class, "single_value/float/");
+	SINGLE_FLOAT(SingleFloatValue.class, "single_value/float/"),
+	// a relation rather than a literal: the value is the key of another instanz.
+	// The folder sits below single_value/, so it does not meet the instanz/ one
+	// InstanzServiceImpl writes into
+	SINGLE_INSTANZ(SingleInstanzValue.class, "single_value/instanz/");
 
 	private final Class<? extends ISingleValue<?>> _clazz;
 

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -47,6 +47,12 @@ public abstract class AInstanz implements IInstanz {
 
 	private BiMap<String, String> _singleInstanzKeyValueMap;
 
+	// the backward direction of a SINGLE_INSTANZ relation - see
+	// IInstanz.getReferencingValueKeys. No field initializer for the same reason as
+	// the maps above: Gson leaves what the json does not name at null, and an
+	// instanz written before this field existed names it nowhere
+	private Set<String> _referencingValueKeys;
+
 	// the only constructor, and it takes the key alone: a parent set here would be
 	// set past IInstanzService, so neither would ChangePropagationListener pull the
 	// other side along nor would a delta be written. Use
@@ -140,5 +146,26 @@ public abstract class AInstanz implements IInstanz {
 	@Override
 	public Collection<String> getChildren() {
 		return _childKeys;
+	}
+
+	@Override
+	public Collection<String> getReferencingValueKeys() {
+		if (_referencingValueKeys == null) {
+			_referencingValueKeys = Collections.synchronizedSet(new HashSet<String>());
+		}
+		return _referencingValueKeys;
+	}
+
+	@Override
+	public boolean addReferencingValueKey(String valueKey) {
+		if (valueKey == null || valueKey.isBlank()) {
+			return false;
+		}
+		return getReferencingValueKeys().add(valueKey);
+	}
+
+	@Override
+	public boolean removeReferencingValueKey(String valueKey) {
+		return getReferencingValueKeys().remove(valueKey);
 	}
 }

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/AInstanz.java
@@ -45,6 +45,8 @@ public abstract class AInstanz implements IInstanz {
 
 	private BiMap<String, String> _singleFloatKeyValueMap;
 
+	private BiMap<String, String> _singleInstanzKeyValueMap;
+
 	// the only constructor, and it takes the key alone: a parent set here would be
 	// set past IInstanzService, so neither would ChangePropagationListener pull the
 	// other side along nor would a delta be written. Use
@@ -125,6 +127,11 @@ public abstract class AInstanz implements IInstanz {
 				_singleFloatKeyValueMap = HashBiMap.create();
 			}
 			return _singleFloatKeyValueMap;
+		case SINGLE_INSTANZ:
+			if (_singleInstanzKeyValueMap == null) {
+				_singleInstanzKeyValueMap = HashBiMap.create();
+			}
+			return _singleInstanzKeyValueMap;
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleInstanzValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleInstanzValue.java
@@ -52,9 +52,16 @@ public class SingleInstanzValue extends ASingleValue<String> {
 		return KEY.matcher(value).matches();
 	}
 
+	/**
+	 * Takes a key, and takes the empty string back as well. Pointing nowhere is a
+	 * state this value has - it is the one a fresh one starts in - and it is where
+	 * a reference is put back to when its target is deleted, so the way in has to
+	 * exist. {@link #accepts} is the narrower question, and the dialog asks that
+	 * one: nothing chosen must not become a value.
+	 */
 	@Override
 	public boolean tryToSetValue(Object value) {
-		return value instanceof String s && accepts(s) && setValue(s);
+		return value instanceof String s && (s.isEmpty() || accepts(s)) && setValue(s);
 	}
 
 	@Override

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleInstanzValue.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/impl/value/SingleInstanzValue.java
@@ -1,0 +1,75 @@
+package de.tonsias.basis.model.impl.value;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.interfaces.IInstanz;
+
+/**
+ * A relation: the attribute of one {@link IInstanz} pointing at another one.
+ * <p>
+ * The value is the <em>key</em> of the target, not the target itself. Everything
+ * in this model is referenced by string key rather than by object reference, and
+ * this bundle has no OSGi dependency to resolve one with - the service does that,
+ * through {@code IInstanzService.resolveInstanzValue}. Keeping the key here is
+ * also what lets the value be persisted by the same Gson as every other one: a
+ * resolved {@link IInstanz} would be written into this value's own file.
+ * </p>
+ */
+public class SingleInstanzValue extends ASingleValue<String> {
+
+	/** the shape of a key - see {@link #accepts} */
+	private static final Pattern KEY = Pattern.compile("[0-9a-z]+");
+
+	public SingleInstanzValue(String key) {
+		super(key);
+		// a fresh reference points nowhere, the way a fresh string is empty. It is not
+		// a key accepts would take, so the dialog keeps OK off until one is chosen
+		this.setValue("");
+	}
+
+	public SingleInstanzValue(String key, String instanzKey, Set<String> connectedInstanzes) {
+		super(key, instanzKey, connectedInstanzes);
+	}
+
+	/**
+	 * Whether this text has the shape of a key: base 36, lower case only, as
+	 * {@code KeyServiceImpl} hands them out. Whether an instanz of that key
+	 * <em>exists</em> is a question this bundle cannot ask - the key service and the
+	 * instanz service both live in {@code de.tonsias.basis.osgi}, which depends on
+	 * this one and not the other way round. A key that resolves to nothing is
+	 * therefore accepted here and comes back empty from the service.
+	 * <p>
+	 * The dialog asks the same question for its OK button, so there is no second
+	 * rule that could drift.
+	 * </p>
+	 */
+	public static boolean accepts(String value) {
+		if (value == null) {
+			return false;
+		}
+		return KEY.matcher(value).matches();
+	}
+
+	@Override
+	public boolean tryToSetValue(Object value) {
+		return value instanceof String s && accepts(s) && setValue(s);
+	}
+
+	@Override
+	public String getPath() {
+		return SingleValueType.SINGLE_INSTANZ.getPath();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(this.getOwnKey()).append(" ");
+		builder.append(this.getValue()).append(" ");
+		String[] string = this.getClass().toString().split("\\.");
+		builder.append(": ").append(string[string.length - 1]);
+		return builder.toString();
+	}
+
+}

--- a/de.tonsias.basis.model/src/de/tonsias/basis/model/interfaces/IInstanz.java
+++ b/de.tonsias.basis.model/src/de/tonsias/basis/model/interfaces/IInstanz.java
@@ -57,4 +57,35 @@ public interface IInstanz extends IObject, ISavePathOwner {
 	void deleteKeys(SingleValueType type, String... keys);
 
 	void deleteParam(SingleValueType type, String... names);
+
+	// relation section
+
+	/**
+	 * The other end of a {@code SingleValueType.SINGLE_INSTANZ} relation: the keys
+	 * of the values pointing <em>at</em> this instanz. A relation is stored on the
+	 * value alone - it carries the key of its target - so without this set nothing
+	 * could ever answer which values a given instanz is the target of, and a
+	 * deleted instanz would leave every one of them holding a key that resolves to
+	 * nothing.
+	 * <p>
+	 * Kept in sync by {@code ChangePropagationListener}, like both ends of every
+	 * other relation. Do not fill it directly: a reference set past
+	 * {@code IInstanzService} writes no delta and would be lost on the next save.
+	 * </p>
+	 *
+	 * @return the value keys, live
+	 */
+	Collection<String> getReferencingValueKeys();
+
+	/**
+	 * @param valueKey of the {@code SingleInstanzValue} now pointing here
+	 * @return true if it was not recorded before
+	 */
+	boolean addReferencingValueKey(String valueKey);
+
+	/**
+	 * @param valueKey of the {@code SingleInstanzValue} no longer pointing here
+	 * @return true if it was recorded before
+	 */
+	boolean removeReferencingValueKey(String valueKey);
 }

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ChangePropagationSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ChangePropagationSystemTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
@@ -297,6 +298,133 @@ public class ChangePropagationSystemTest {
 				SingleValueType.SINGLE_STRING, LinkedInstanzChangeEvent.ChangeType.REMOVE, List.of(owner.getOwnKey())));
 
 		assertThat(owner.getSingleValues(SingleValueType.SINGLE_STRING).containsKey("fabricated-remove"), is(true));
+	}
+
+	// ---------- the relation, which is held at both ends too ----------
+
+	/**
+	 * A relation is created pointing somewhere already, so there is no later change
+	 * for the target to learn from - the new event is where it is told.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testNewRelation_isRecordedOnTheInstanzItPointsAt() {
+		IInstanz owner = newInstanz();
+		IInstanz target = newInstanz();
+
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		assertThat(target.getReferencingValueKeys(), contains(relation.getOwnKey()));
+	}
+
+	/** and a value of any other type leaves every reference set alone */
+	@Test
+	void testNewStringValue_isNoRelationAndRecordsNothing() {
+		IInstanz owner = newInstanz();
+		IInstanz other = newInstanz();
+
+		_svs.createNew(SingleStringValue.class, owner.getOwnKey(), "parameter", other.getOwnKey(), Type.SEND);
+
+		assertThat(other.getReferencingValueKeys(), hasSize(0));
+	}
+
+	/** repointing a relation is two changes, and both ends have to follow */
+	@Test
+	void testChangedRelation_movesTheRecordToTheNewTarget() {
+		IInstanz owner = newInstanz();
+		IInstanz first = newInstanz();
+		IInstanz second = newInstanz();
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points at",
+				first.getOwnKey(), Type.SEND);
+
+		_svs.changeValue(relation.getOwnKey(), second.getOwnKey(), Type.SEND);
+
+		assertThat(first.getReferencingValueKeys(), hasSize(0));
+		assertThat(second.getReferencingValueKeys(), contains(relation.getOwnKey()));
+	}
+
+	@Test
+	void testDeletedRelation_isTakenOffTheTarget() {
+		IInstanz owner = newInstanz();
+		IInstanz target = newInstanz();
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		_svs.removeValue(relation, Type.SEND);
+
+		assertThat(target.getReferencingValueKeys(), hasSize(0));
+	}
+
+	/**
+	 * The whole point of the backward end: the target is gone, so every relation
+	 * that named it is put back to pointing nowhere. The value itself stays - it is
+	 * an attribute of its owner, under a name that owner gave it, and deleting a
+	 * target is no reason to take an attribute off somebody else.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testDeletedInstanz_emptiesEveryRelationPointingAtIt() {
+		IInstanz owner = newInstanz();
+		IInstanz target = newInstanz();
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		_inse.removeSubtreeInstanz(target.getOwnKey(), Type.SEND);
+
+		assertThat(relation.getValue(), is(""));
+		assertThat(_inse.resolveInstanzValue(relation), is(java.util.Optional.empty()));
+		assertThat("the attribute itself is untouched",
+				owner.getSingleValues(SingleValueType.SINGLE_INSTANZ).get(relation.getOwnKey()), is("points at"));
+		assertThat(target.getReferencingValueKeys(), hasSize(0));
+	}
+
+	/** a whole branch: every instanz below the deleted one is a target too */
+	@Test
+	void testDeletedInstanz_reachesTheRelationsPointingIntoItsSubtree() {
+		IInstanz owner = newInstanz();
+		IInstanz branch = newInstanz();
+		IInstanz leaf = _inse.createInstanz(branch.getOwnKey(), Type.SEND);
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points deep",
+				leaf.getOwnKey(), Type.SEND);
+
+		_inse.removeSubtreeInstanz(branch.getOwnKey(), Type.SEND);
+
+		assertThat(relation.getValue(), is(""));
+	}
+
+	/**
+	 * Two relations on the same target, and the second one must not be skipped: the
+	 * set is walked over a copy, because emptying a value comes straight back round
+	 * and takes its key out of exactly that set.
+	 */
+	@Test
+	void testDeletedInstanz_emptiesEveryOneOfThem() {
+		IInstanz owner = newInstanz();
+		IInstanz target = newInstanz();
+		SingleInstanzValue first = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "first", target.getOwnKey(),
+				Type.SEND);
+		SingleInstanzValue second = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "second",
+				target.getOwnKey(), Type.SEND);
+
+		_inse.removeSubtreeInstanz(target.getOwnKey(), Type.SEND);
+
+		assertThat(first.getValue(), is(""));
+		assertThat(second.getValue(), is(""));
+	}
+
+	/** an instanz pointing at itself is allowed, and deleting it has to terminate */
+	@Test
+	void testDeletedInstanz_aRelationOntoItselfIsEmptiedToo() {
+		IInstanz self = newInstanz();
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, self.getOwnKey(), "points at itself",
+				self.getOwnKey(), Type.SEND);
+
+		_inse.removeSubtreeInstanz(self.getOwnKey(), Type.SEND);
+
+		assertThat(relation.getValue(), is(""));
 	}
 
 	// ---------- malformed payloads ----------

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ChangePropagationSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/ChangePropagationSystemTest.java
@@ -381,6 +381,28 @@ public class ChangePropagationSystemTest {
 		assertThat(target.getReferencingValueKeys(), hasSize(0));
 	}
 
+	/**
+	 * The set on the target is the only way to the relation, and it holds a key -
+	 * so the value behind it has to be reachable even when nothing in this session
+	 * has touched it. That is the state every relation is in after a restart.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/78">#78</a>
+	 */
+	@Test
+	void testDeletedInstanz_reachesARelationThatIsOnDiskOnly() {
+		IInstanz owner = newInstanz();
+		IInstanz target = newInstanz();
+		String relationKey = _svs.createNew(SingleInstanzValue.class, owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND).getOwnKey();
+		ProductRuntime.flushDeltas();
+		_svs.removeFromCache(relationKey);
+
+		_inse.removeSubtreeInstanz(target.getOwnKey(), Type.SEND);
+
+		assertThat(_svs.resolveKey(SingleValueType.SINGLE_INSTANZ.getPath(), relationKey, SingleInstanzValue.class)
+				.map(SingleInstanzValue::getValue), is(java.util.Optional.of("")));
+	}
+
 	/** a whole branch: every instanz below the deleted one is a target too */
 	@Test
 	void testDeletedInstanz_reachesTheRelationsPointingIntoItsSubtree() {

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/InstanzServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/InstanzServiceSystemTest.java
@@ -35,6 +35,7 @@ import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ChangeType;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedChildChangeEvent;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedReferenceChangeEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedValueChangeEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ParentChange;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ValueRenameEvent;
@@ -437,6 +438,84 @@ public class InstanzServiceSystemTest {
 		assertThat(_recorder.dataOf(InstanzEventConstants.VALUE_LIST_CHANGE, LinkedValueChangeEvent.class).stream()
 				.map(LinkedValueChangeEvent::_key).toList(),
 				containsInAnyOrder(one.getOwnKey(), other.getOwnKey()));
+	}
+
+	// ---------- the backward end of a relation ----------
+
+	/**
+	 * A relation is stored on the value, which carries the key of its target. The
+	 * target keeps the other end, and this is the pair of calls that writes it -
+	 * without them nothing could answer which values point at a given instanz.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testPutReferencingValue_recordsTheRelationOnTheTargetAndFires() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.putReferencingValue(target.getOwnKey(), "vKey", Type.SEND), is(true));
+
+		assertThat(target.getReferencingValueKeys(), contains("vKey"));
+		LinkedReferenceChangeEvent data = _recorder.onlyDataOf(InstanzEventConstants.REFERENCE_LIST_CHANGE,
+				LinkedReferenceChangeEvent.class);
+		assertThat(data._key(), is(target.getOwnKey()));
+		assertThat(data._changeType(), is(ChangeType.ADD));
+		assertThat(data._valueKeys(), contains("vKey"));
+	}
+
+	/** the guard that ends a chain: already recorded is nothing to report */
+	@Test
+	void testPutReferencingValue_aSecondTimeIsRejectedAndSilent() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.putReferencingValue(target.getOwnKey(), "vKey", Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.putReferencingValue(target.getOwnKey(), "vKey", Type.SEND), is(false));
+
+		assertThat(_recorder.events(), hasSize(0));
+	}
+
+	@Test
+	void testRemoveReferencingValue_takesItBackOutAndFires() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.putReferencingValue(target.getOwnKey(), "vKey", Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeReferencingValue(target.getOwnKey(), "vKey", Type.SEND), is(true));
+
+		assertThat(target.getReferencingValueKeys(), hasSize(0));
+		LinkedReferenceChangeEvent data = _recorder.onlyDataOf(InstanzEventConstants.REFERENCE_LIST_CHANGE,
+				LinkedReferenceChangeEvent.class);
+		assertThat(data._changeType(), is(ChangeType.REMOVE));
+	}
+
+	@Test
+	void testRemoveReferencingValue_oneThatWasNeverThereIsRejectedAndSilent() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat(_inse.removeReferencingValue(target.getOwnKey(), "vKey", Type.SEND), is(false));
+
+		assertThat(_recorder.events(), hasSize(0));
+	}
+
+	/**
+	 * A relation pointing nowhere holds the empty string, and the propagation hands
+	 * that on as the target key. It is no key to look a file up with, so it has to
+	 * be turned away before the resolve rather than after it.
+	 */
+	@Test
+	void testPutReferencingValue_neitherEndMayBeBlank() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		assertThat("no target", _inse.putReferencingValue("", "vKey", Type.SEND), is(false));
+		assertThat("no value", _inse.putReferencingValue(target.getOwnKey(), "", Type.SEND), is(false));
+		assertThat("no target", _inse.removeReferencingValue(null, "vKey", Type.SEND), is(false));
+		assertThat("an unresolvable target", _inse.putReferencingValue("no-such-key", "vKey", Type.SEND), is(false));
+
+		assertThat(_recorder.events(), hasSize(0));
 	}
 
 	// ---------- delete ----------

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
@@ -213,11 +213,10 @@ public class SingleValueServiceSystemTest {
 	}
 
 	/**
-	 * A reference that points nowhere comes back empty rather than throwing: a fresh
-	 * one holds the empty string, and a stored one keeps its key after the target
-	 * has been deleted, because nothing records who points at an instanz.
-	 *
-	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 * A reference that points nowhere comes back empty rather than throwing. That
+	 * is the state a fresh one is in, and the one a stored one is put back into
+	 * when its target is deleted; a key that resolves to nothing is what a
+	 * hand-edited file can still hold.
 	 */
 	@Test
 	void testResolveInstanzValue_pointingNowhereIsEmpty() {
@@ -229,6 +228,42 @@ public class SingleValueServiceSystemTest {
 		assertThat("no value at all", _inse.resolveInstanzValue(null), is(Optional.empty()));
 		assertThat("the empty string a fresh one holds",
 				_inse.resolveInstanzValue(new SingleInstanzValue("unsaved")), is(Optional.empty()));
+	}
+
+	/**
+	 * The backward end of the relation is stored on the target, so it has to travel
+	 * to disk with it - a set rebuilt only in memory would leave every relation
+	 * dangling again after a restart.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testSaveAll_theTargetCarriesTheRelationBackThroughItsOwnFile() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		SingleInstanzValue relation = _svs.createNew(SingleInstanzValue.class, _owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		assertThat(_inse.saveAll(Set.of(target.getOwnKey())), is(true));
+
+		assertThat(ProductRuntime.reloadInstanz(target.getOwnKey()).getReferencingValueKeys(),
+				contains(relation.getOwnKey()));
+	}
+
+	/**
+	 * An instanz written before the type existed names no set at all. Gson leaves
+	 * the field at {@code null} then, and the getter is the one place that makes
+	 * one - reading such a file must not blow up on the first relation pointing at
+	 * it.
+	 */
+	@Test
+	void testReferencingValueKeys_anInstanzWithoutTheFieldStartsEmpty() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_inse.saveAll(Set.of(target.getOwnKey()));
+
+		IInstanz reloaded = ProductRuntime.reloadInstanz(target.getOwnKey());
+
+		assertThat(reloaded.getReferencingValueKeys(), hasSize(0));
+		assertThat(reloaded.addReferencingValueKey("vKey"), is(true));
 	}
 
 	@Test

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -159,6 +160,75 @@ public class SingleValueServiceSystemTest {
 				SingleFloatValue.class);
 		assertThat(reloaded.getValue(), is(-0.5f));
 		assertThat(reloaded.getConnectedInstanzKeys(), contains(_owner.getOwnKey()));
+	}
+
+	// ---------- the relation ----------
+
+	/**
+	 * A relation is a value like any other on the way in: it lands in the map of its
+	 * own type, and what it stores is the key of the instanz it points at.
+	 */
+	@Test
+	void testCreateNew_instanzValueStoresTheTargetKey() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		_recorder.clear();
+
+		SingleInstanzValue created = _svs.createNew(SingleInstanzValue.class, _owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		assertThat(created.getValue(), is(target.getOwnKey()));
+		assertThat(_owner.getSingleValues(SingleValueType.SINGLE_INSTANZ).get(created.getOwnKey()), is("points at"));
+		assertThat(_owner.getSingleValues(SingleValueType.SINGLE_STRING).containsKey(created.getOwnKey()), is(false));
+		assertThat(_recorder.onlyDataOf(SingleValueEventConstants.NEW, SingleValueNewEvent.class)._type(),
+				is(SingleValueType.SINGLE_INSTANZ));
+	}
+
+	/**
+	 * The relation has a folder of its own below {@code single_value/}, so it never
+	 * meets the {@code instanz/} folder the target itself is written into.
+	 */
+	@Test
+	void testSaveAll_anInstanzValueSurvivesTheRoundTripThroughItsOwnFolder() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		SingleInstanzValue created = _svs.createNew(SingleInstanzValue.class, _owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		assertThat(_svs.saveAll(Set.of(created.getOwnKey())), is(true));
+
+		assertThat(ProductRuntime.valueFileExists(SingleValueType.SINGLE_INSTANZ, created.getOwnKey()), is(true));
+		SingleInstanzValue reloaded = ProductRuntime.reloadValue(SingleValueType.SINGLE_INSTANZ, created.getOwnKey(),
+				SingleInstanzValue.class);
+		assertThat(reloaded.getValue(), is(target.getOwnKey()));
+		assertThat(reloaded.getConnectedInstanzKeys(), contains(_owner.getOwnKey()));
+	}
+
+	/** the relation followed, which is the whole point of the type */
+	@Test
+	void testResolveInstanzValue_findsTheTarget() {
+		IInstanz target = _inse.createInstanz(ROOT, Type.SEND);
+		SingleInstanzValue created = _svs.createNew(SingleInstanzValue.class, _owner.getOwnKey(), "points at",
+				target.getOwnKey(), Type.SEND);
+
+		assertThat(_inse.resolveInstanzValue(created), is(Optional.of(target)));
+	}
+
+	/**
+	 * A reference that points nowhere comes back empty rather than throwing: a fresh
+	 * one holds the empty string, and a stored one keeps its key after the target
+	 * has been deleted, because nothing records who points at an instanz.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	@Test
+	void testResolveInstanzValue_pointingNowhereIsEmpty() {
+		SingleInstanzValue fresh = _svs.createNew(SingleInstanzValue.class, _owner.getOwnKey(), "unset",
+				_owner.getOwnKey(), Type.SEND);
+		fresh.tryToSetValue("zzzzzz");
+
+		assertThat("a key no instanz carries", _inse.resolveInstanzValue(fresh), is(Optional.empty()));
+		assertThat("no value at all", _inse.resolveInstanzValue(null), is(Optional.empty()));
+		assertThat("the empty string a fresh one holds",
+				_inse.resolveInstanzValue(new SingleInstanzValue("unsaved")), is(Optional.empty()));
 	}
 
 	@Test

--- a/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
+++ b/de.tonsias.basis.osgi.test/src/de/tonsias/basis/osgi/test/system/SingleValueServiceSystemTest.java
@@ -329,6 +329,31 @@ public class SingleValueServiceSystemTest {
 				SingleIntegerValue.class), is(Optional.empty()));
 	}
 
+	/**
+	 * A folder without the file is no answer, and the service may not remember it
+	 * as one. It used to put the {@code null} into the cache, and from then on the
+	 * key counted as asked and answered: the very next call, in the right folder,
+	 * got the same nothing back. Looking in one folder after another is what the
+	 * service itself does when a key does not say its type, so the first look is
+	 * regularly the wrong one.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/79">#79</a>
+	 */
+	@Test
+	void testResolveKey_aMissTheWrongFolderGivesIsNotRemembered() {
+		SingleStringValue created = newStringValue("parameter", "content");
+		String key = created.getOwnKey();
+		ProductRuntime.flushDeltas();
+		_svs.removeFromCache(key);
+
+		assertThat("no string value lies in the float folder",
+				_svs.resolveKey(SingleValueType.SINGLE_FLOAT.getPath(), key, SingleFloatValue.class),
+				is(Optional.empty()));
+
+		assertThat("and the right folder still answers", _svs.resolveKey(STRING_PATH, key, SingleStringValue.class)
+				.map(SingleStringValue::getValue), is(Optional.of("content")));
+	}
+
 	@Test
 	void testResolveKeys_skipsWhatCannotBeResolved() {
 		SingleStringValue known = newStringValue("parameter", "content");
@@ -376,6 +401,69 @@ public class SingleValueServiceSystemTest {
 		assertThat(_svs.changeValue(value.getOwnKey(), 42, Type.SEND), is(false));
 
 		assertThat(value.getValue(), is("text"));
+		assertThat(_recorder.events(), hasSize(0));
+	}
+
+	/**
+	 * A value that has not been touched in this session is not in the cache - after
+	 * a restart no value is. Reading the cache and nothing else made every one of
+	 * them a {@code NullPointerException} out of the service, and the folder the
+	 * value lies in is what says which type it is.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/78">#78</a>
+	 */
+	@Test
+	void testChangeValue_reachesAValueThatIsOnDiskOnly() {
+		SingleStringValue value = newStringValue("parameter", "old");
+		String key = value.getOwnKey();
+		ProductRuntime.flushDeltas();
+		_svs.removeFromCache(key);
+		_recorder.clear();
+
+		assertThat(_svs.changeValue(key, "new", Type.SEND), is(true));
+
+		ValueChangeEvent data = _recorder.onlyDataOf(SingleValueEventConstants.VALUE_CHANGE, ValueChangeEvent.class);
+		assertThat("the type comes out of the folder it was found in", data._type(),
+				is(SingleValueType.SINGLE_STRING));
+		assertThat(data._oldValue(), is("old"));
+		assertThat(_svs.resolveKey(STRING_PATH, key, SingleStringValue.class).get().getValue(), is("new"));
+	}
+
+	/** and a key nothing backs is a no-op rather than a failure of the service */
+	@Test
+	void testChangeValue_aKeyWithoutAValueIsSilent() {
+		_recorder.clear();
+
+		assertThat(_svs.changeValue("no-such-key", "new", Type.SEND), is(false));
+		assertThat(_svs.changeValue(null, "new", Type.SEND), is(false));
+
+		assertThat(_recorder.events(), hasSize(0));
+	}
+
+	/** {@code markSingleValueAsDelete} read the cache the same way - @see #78 */
+	@Test
+	void testMarkSingleValueAsDelete_reachesAValueThatIsOnDiskOnly() {
+		SingleStringValue value = newStringValue("parameter", "content");
+		String key = value.getOwnKey();
+		ProductRuntime.flushDeltas();
+		_svs.removeFromCache(key);
+		_recorder.clear();
+
+		_svs.markSingleValueAsDelete(key, Type.SEND);
+
+		SingleValueDeleteEvent data = _recorder.onlyDataOf(SingleValueEventConstants.DELETE,
+				SingleValueDeleteEvent.class);
+		assertThat(data._key(), is(key));
+		assertThat(data._type(), is(SingleValueType.SINGLE_STRING));
+		assertThat("the owner it was stored with", data._ownerKeys(), contains(_owner.getOwnKey()));
+	}
+
+	@Test
+	void testMarkSingleValueAsDelete_aKeyWithoutAValueIsSilent() {
+		_recorder.clear();
+
+		_svs.markSingleValueAsDelete("no-such-key", Type.SEND);
+
 		assertThat(_recorder.events(), hasSize(0));
 	}
 

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/DeltaServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/DeltaServiceImpl.java
@@ -155,6 +155,12 @@ public class DeltaServiceImpl implements IDeltaService {
 			var value3 = LinkedValueChangeEvent.class.cast(property);
 			instanzKeysToSave.add(value3._key());
 			break;
+		case InstanzEventConstants.REFERENCE_LIST_CHANGE:
+			// the set of values pointing at an instanz is stored on the instanz, so the
+			// target is what has to be written - the value itself did not change here
+			var value7 = LinkedReferenceChangeEvent.class.cast(property);
+			instanzKeysToSave.add(value7._key());
+			break;
 		case InstanzEventConstants.DELETE:
 			var value4 = InstanzEvent.class.cast(property);
 			instanzKeysToDelete.add(value4._key());

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
@@ -22,6 +22,7 @@ import de.tonsias.basis.data.access.osgi.intf.LoadService;
 import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.Instanz;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
@@ -100,6 +101,20 @@ public class InstanzServiceImpl implements IInstanzService {
 		}
 
 		return Optional.empty();
+	}
+
+	@Override
+	public Optional<IInstanz> resolveInstanzValue(SingleInstanzValue value) {
+		if (value == null) {
+			return Optional.empty();
+		}
+		String targetKey = value.getValue();
+		// a fresh reference holds the empty string, which resolveKey would look for a
+		// file named "instanz/.json" with
+		if (targetKey == null || targetKey.isBlank()) {
+			return Optional.empty();
+		}
+		return resolveKey(targetKey);
 	}
 
 	@Override

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/InstanzServiceImpl.java
@@ -32,6 +32,7 @@ import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ChangeType;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.InstanzEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedChildChangeEvent;
+import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedReferenceChangeEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.LinkedValueChangeEvent;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ParentChange;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants.ValueRenameEvent;
@@ -115,6 +116,42 @@ public class InstanzServiceImpl implements IInstanzService {
 			return Optional.empty();
 		}
 		return resolveKey(targetKey);
+	}
+
+	@Override
+	public boolean putReferencingValue(String instanzKey, String valueKey, Type eventType) {
+		Optional<IInstanz> instanz = resolvableTarget(instanzKey, valueKey);
+		if (instanz.isEmpty() || !instanz.get().addReferencingValueKey(valueKey)) {
+			return false;
+		}
+
+		var data = new LinkedReferenceChangeEvent(instanzKey, ChangeType.ADD, List.of(valueKey));
+		fireEvent(eventType, InstanzEventConstants.REFERENCE_LIST_CHANGE, data);
+		return true;
+	}
+
+	@Override
+	public boolean removeReferencingValue(String instanzKey, String valueKey, Type eventType) {
+		Optional<IInstanz> instanz = resolvableTarget(instanzKey, valueKey);
+		if (instanz.isEmpty() || !instanz.get().removeReferencingValueKey(valueKey)) {
+			return false;
+		}
+
+		var data = new LinkedReferenceChangeEvent(instanzKey, ChangeType.REMOVE, List.of(valueKey));
+		fireEvent(eventType, InstanzEventConstants.REFERENCE_LIST_CHANGE, data);
+		return true;
+	}
+
+	/**
+	 * The instanz both reference methods work on. A reference pointing nowhere
+	 * holds the empty string, and that is no key to look a file up with - it has to
+	 * be turned away before {@link #resolveKey} goes looking for {@code instanz/}.
+	 */
+	private Optional<IInstanz> resolvableTarget(String instanzKey, String valueKey) {
+		if (instanzKey == null || instanzKey.isBlank() || valueKey == null || valueKey.isBlank()) {
+			return Optional.empty();
+		}
+		return resolveKey(instanzKey);
 	}
 
 	@Override

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -25,6 +25,7 @@ import de.tonsias.basis.data.access.osgi.intf.SaveService;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.ISingleValue;
@@ -123,6 +124,8 @@ public class SingleValueServiceImpl implements ISingleValueService {
 			return (E) new SingleBooleanValue(key);
 		case SINGLE_FLOAT:
 			return (E) new SingleFloatValue(key);
+		case SINGLE_INSTANZ:
+			return (E) new SingleInstanzValue(key);
 		default:
 			throw new IllegalArgumentException("Unexpected value: " + type);
 		}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/impl/SingleValueServiceImpl.java
@@ -71,9 +71,47 @@ public class SingleValueServiceImpl implements ISingleValueService {
 		if (path == null || path.isBlank()) {
 			return Optional.empty();
 		}
+
 		E singleValue = _loadService.loadFromGson(path + key, clazz);
+		if (singleValue == null) {
+			// no file is no answer, and it is no answer worth remembering either: a null
+			// left in the cache counts as "asked and answered" from then on, so the key
+			// would never resolve again in this session - not even once its file is
+			// there, and not even when the next caller looks in the right folder. See
+			// https://github.com/Tobias-Bonsack/Tonsias/issues/79
+			return Optional.empty();
+		}
+
 		_cache.put(key, singleValue);
-		return Optional.ofNullable(singleValue);
+		return Optional.of(singleValue);
+	}
+
+	/**
+	 * The value behind a key, whatever its type. The cache answers first; a value
+	 * that has not been touched in this session is looked for in one type folder
+	 * after the other, the same way {@link #deleteFile} finds the file it has to
+	 * remove. A key alone does not say which type it belongs to - only the folder
+	 * it lies in does.
+	 *
+	 * @return the value, or empty for a key no folder holds a file for
+	 */
+	private Optional<ISingleValue<?>> resolveAnyKey(String key) {
+		if (key == null || key.isBlank()) {
+			return Optional.empty();
+		}
+
+		ISingleValue<?> cached = _cache.get(key);
+		if (cached != null) {
+			return Optional.of(cached);
+		}
+
+		for (SingleValueType type : SingleValueType.values()) {
+			Optional<? extends ISingleValue<?>> loaded = resolveKey(type.getPath(), key, type.getClazz());
+			if (loaded.isPresent()) {
+				return Optional.of(loaded.get());
+			}
+		}
+		return Optional.empty();
 	}
 
 	@Override
@@ -153,7 +191,16 @@ public class SingleValueServiceImpl implements ISingleValueService {
 
 	@Override
 	public boolean changeValue(String ownKey, Object newValue, IEventBrokerBridge.Type eventType) {
-		ISingleValue<?> value = _cache.get(ownKey);
+		// off the cache alone this used to throw a NullPointerException for every value
+		// that had not been touched in this session - which after a restart is every
+		// value there is, see
+		// https://github.com/Tobias-Bonsack/Tonsias/issues/78
+		Optional<ISingleValue<?>> resolved = resolveAnyKey(ownKey);
+		if (resolved.isEmpty()) {
+			return false;
+		}
+
+		ISingleValue<?> value = resolved.get();
 		Object oldValue = value.getValue();
 		boolean isChanged = value.tryToSetValue(newValue);
 		if (isChanged) {
@@ -174,7 +221,14 @@ public class SingleValueServiceImpl implements ISingleValueService {
 
 	@Override
 	public void markSingleValueAsDelete(String singleValueKeyToMark, Type eventType) {
-		var value = _cache.get(singleValueKeyToMark);
+		// the same cache assumption changeValue made, and the same fix, see
+		// https://github.com/Tobias-Bonsack/Tonsias/issues/78
+		Optional<ISingleValue<?>> resolved = resolveAnyKey(singleValueKeyToMark);
+		if (resolved.isEmpty()) {
+			return;
+		}
+
+		ISingleValue<?> value = resolved.get();
 		Optional<SingleValueType> optional = SingleValueType.getByClass(value.getClass());
 		optional.ifPresent(type -> {
 			// a live view of the connections, so it has to be copied before they are cut -

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IInstanzService.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IInstanzService.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionException;
 
 import de.tonsias.basis.data.access.osgi.intf.DeleteService;
 import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.model.interfaces.ISingleValue;
 import de.tonsias.basis.osgi.util.ChangePropagationListener;
@@ -37,6 +38,20 @@ public interface IInstanzService {
 	 * @return collection of resolvable {@link IInstanz}
 	 */
 	Collection<IInstanz> resolveKeys(Collection<String> keys);
+
+	/**
+	 * Follows a relation: a {@link SingleInstanzValue} carries the key of the
+	 * instanz it points at, and this is the one place that turns it back into the
+	 * object. The value itself cannot - {@code de.tonsias.basis.model} has no OSGi
+	 * dependency to reach a service with.
+	 *
+	 * @param value the reference to follow, may be {@code null}
+	 * @return the target, or empty when the value points nowhere - which a stored
+	 *         reference does once its target has been deleted, because nothing
+	 *         records who points at an instanz, see
+	 *         <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 */
+	Optional<IInstanz> resolveInstanzValue(SingleInstanzValue value);
 
 	/**
 	 * Creates a new {@link IInstanz}, but does not save it

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IInstanzService.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/IInstanzService.java
@@ -46,12 +46,36 @@ public interface IInstanzService {
 	 * dependency to reach a service with.
 	 *
 	 * @param value the reference to follow, may be {@code null}
-	 * @return the target, or empty when the value points nowhere - which a stored
-	 *         reference does once its target has been deleted, because nothing
-	 *         records who points at an instanz, see
-	 *         <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/74">#74</a>
+	 * @return the target, or empty when the value points nowhere - the state a
+	 *         fresh reference is in, and the one it is put back into when its
+	 *         target is deleted
 	 */
 	Optional<IInstanz> resolveInstanzValue(SingleInstanzValue value);
+
+	/**
+	 * Records that a {@code SingleInstanzValue} points at this instanz - the
+	 * backward direction of the relation, which the value itself does not carry.
+	 * The forward direction is the value's own content and stays
+	 * {@code ISingleValueService.changeValue}'s;
+	 * {@link ChangePropagationListener} is what calls both.
+	 *
+	 * @param instanzKey of the target being pointed at
+	 * @param valueKey   of the relation doing the pointing
+	 * @return true if it was newly recorded - false, and no event, when it was
+	 *         already there, so the propagation cannot re-enter itself
+	 */
+	boolean putReferencingValue(String instanzKey, String valueKey, IEventBrokerBridge.Type eventType);
+
+	/**
+	 * Takes a relation back out of the target's set, for a relation that was moved
+	 * elsewhere or deleted.
+	 *
+	 * @param instanzKey of the target no longer pointed at
+	 * @param valueKey   of the relation that pointed at it
+	 * @return true if it was recorded before
+	 * @see #putReferencingValue(String, String, IEventBrokerBridge.Type)
+	 */
+	boolean removeReferencingValue(String instanzKey, String valueKey, IEventBrokerBridge.Type eventType);
 
 	/**
 	 * Creates a new {@link IInstanz}, but does not save it

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/non/service/InstanzEventConstants.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/intf/non/service/InstanzEventConstants.java
@@ -46,12 +46,21 @@ public interface InstanzEventConstants {
 	final String VALUE_LIST_CHANGE = INSTANZ + "/delta/valueChange";
 
 	/**
+	 * The instanz is the <em>target</em> of a relation, not its owner: a
+	 * {@code SingleInstanzValue} started or stopped pointing at it.
+	 * <p>
+	 * {@link IEventBroker#DATA} maps to {@link LinkedReferenceChangeEvent}
+	 * </p>
+	 */
+	final String REFERENCE_LIST_CHANGE = INSTANZ + "/delta/referenceChange";
+
+	/**
 	 * {@link IEventBroker#DATA} maps to {@link InstanzEvent}
 	 */
 	final String DELETE = INSTANZ + "/delta/delete";
 
 	final List<String> KNOWN_DELTA = List.of(NEW, NAME_CHANGE, VALUE_LIST_CHANGE, CHILD_LIST_CHANGE, DELETE,
-			PARENT_CHANGE);
+			PARENT_CHANGE, REFERENCE_LIST_CHANGE);
 
 	// data and the keys
 
@@ -103,6 +112,25 @@ public interface InstanzEventConstants {
 
 	static record LinkedValueChangeEvent(String _key, SingleValueType _singleValuetype, ChangeType _changeType,
 			Collection<String> _valueKeys) implements KeyEvent {
+
+		@Override
+		public String getKey() {
+			return _key;
+		}
+
+	}
+
+	/**
+	 * The counterpart of {@link LinkedValueChangeEvent} for the relation: there the
+	 * instanz owns the values, here it is what they point at. No
+	 * {@link SingleValueType} field, because there is only one type a relation can
+	 * be.
+	 *
+	 * @param _key        of the instanz being pointed at
+	 * @param _valueKeys  of the {@code SingleInstanzValue}s doing the pointing
+	 */
+	static record LinkedReferenceChangeEvent(String _key, ChangeType _changeType, Collection<String> _valueKeys)
+			implements KeyEvent {
 
 		@Override
 		public String getKey() {

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
@@ -107,13 +107,10 @@ public class ChangePropagationListener {
 	 */
 	private void emptyReferencesPointingAt(IInstanz target) {
 		for (String valueKey : List.copyOf(target.getReferencingValueKeys())) {
-			// changeValue reads the cache and nothing else, so a relation stored in an
-			// earlier session would take it down with a NullPointerException - resolving
-			// first is what puts it there, see
-			// https://github.com/Tobias-Bonsack/Tonsias/issues/78
-			if (relationOf(valueKey).isPresent()) {
-				_singleValue.changeValue(valueKey, "", Type.SEND);
-			}
+			// changeValue resolves off the disk when it has to, so a relation stored in an
+			// earlier session is reached as well - a key the set names and no file backs
+			// answers false and changes nothing
+			_singleValue.changeValue(valueKey, "", Type.SEND);
 		}
 	}
 

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
@@ -107,8 +107,10 @@ public class ChangePropagationListener {
 	 */
 	private void emptyReferencesPointingAt(IInstanz target) {
 		for (String valueKey : List.copyOf(target.getReferencingValueKeys())) {
-			// changeValue reads the cache, and a relation stored in an earlier session has
-			// never been in it - resolving is what puts it there
+			// changeValue reads the cache and nothing else, so a relation stored in an
+			// earlier session would take it down with a NullPointerException - resolving
+			// first is what puts it there, see
+			// https://github.com/Tobias-Bonsack/Tonsias/issues/78
 			if (relationOf(valueKey).isPresent()) {
 				_singleValue.changeValue(valueKey, "", Type.SEND);
 			}

--- a/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
+++ b/de.tonsias.basis.osgi/src/de/tonsias/basis/osgi/util/ChangePropagationListener.java
@@ -1,11 +1,15 @@
 package de.tonsias.basis.osgi.util;
 
+import java.util.List;
+
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.EventTopic;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.osgi.service.event.Event;
 
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
@@ -87,7 +91,28 @@ public class ChangePropagationListener {
 		java.util.Optional<IInstanz> instanz = _instanz.resolveKey(data._key());
 		instanz.ifPresent(i -> {
 			i.getChildren().forEach(child -> _instanz.markInstanzAsDelete(child, Type.SEND));
+			emptyReferencesPointingAt(i);
 		});
+	}
+
+	/**
+	 * Puts every relation pointing at this instanz back to pointing nowhere. The
+	 * value itself is left standing: it is an attribute of somebody else, with a
+	 * name that instanz gave it, and deleting the target is no reason to take an
+	 * attribute off an instanz nobody asked to change.
+	 * <p>
+	 * Copied first, because emptying a value comes back around through
+	 * {@link #changeSingleValueListener} and takes its key out of exactly this set.
+	 * </p>
+	 */
+	private void emptyReferencesPointingAt(IInstanz target) {
+		for (String valueKey : List.copyOf(target.getReferencingValueKeys())) {
+			// changeValue reads the cache, and a relation stored in an earlier session has
+			// never been in it - resolving is what puts it there
+			if (relationOf(valueKey).isPresent()) {
+				_singleValue.changeValue(valueKey, "", Type.SEND);
+			}
+		}
 	}
 
 	/**
@@ -122,6 +147,10 @@ public class ChangePropagationListener {
 		for (String ownerKey : data._ownerKeys()) {
 			_instanz.putSingleValue(ownerKey, data._type(), data._key(), data._name(), Type.SEND);
 		}
+
+		// a relation is created pointing somewhere already, so the target learns about
+		// it here rather than from a change that never comes
+		targetOf(data).ifPresent(target -> _instanz.putReferencingValue(target, data._key(), Type.SEND));
 	}
 
 	@Inject
@@ -129,6 +158,49 @@ public class ChangePropagationListener {
 	public void removeSingleValueListener(@EventTopic(SingleValueEventConstants.DELETE) Event event) {
 		SingleValueDeleteEvent data = (SingleValueDeleteEvent) event.getProperty(IEventBroker.DATA);
 		_instanz.removeValueKey(data._ownerKeys(), data._type(), data._key(), Type.SEND);
+
+		targetOf(data).ifPresent(target -> _instanz.removeReferencingValue(target, data._key(), Type.SEND));
+	}
+
+	/**
+	 * The relation moved from one instanz to another, which is two changes: the old
+	 * target stops being pointed at and the new one starts. Both services answer
+	 * {@code false} and fire nothing when the key is not in the set, or already is,
+	 * so a value that stayed where it was ends the chain here.
+	 */
+	@Inject
+	@Optional
+	public void changeSingleValueListener(@EventTopic(SingleValueEventConstants.VALUE_CHANGE) Event event) {
+		ValueChangeEvent data = (ValueChangeEvent) event.getProperty(IEventBroker.DATA);
+		if (data.getType() != SingleValueType.SINGLE_INSTANZ) {
+			return;
+		}
+
+		if (data._oldValue() instanceof String oldTarget) {
+			_instanz.removeReferencingValue(oldTarget, data._key(), Type.SEND);
+		}
+		if (data._newValue() instanceof String newTarget) {
+			_instanz.putReferencingValue(newTarget, data._key(), Type.SEND);
+		}
+	}
+
+	/**
+	 * Where the relation named by this event points. The single value events carry
+	 * the key and the type of a value, never its content, so the value itself has
+	 * to be read - and only for the one type that has a target at all.
+	 *
+	 * @return the target key, empty for every other type and for a relation
+	 *         pointing nowhere
+	 */
+	private java.util.Optional<String> targetOf(SingleValueEvent data) {
+		if (data.getType() != SingleValueType.SINGLE_INSTANZ) {
+			return java.util.Optional.empty();
+		}
+		return relationOf(data.getKey()).map(SingleInstanzValue::getValue).filter(target -> !target.isBlank());
+	}
+
+	private java.util.Optional<SingleInstanzValue> relationOf(String valueKey) {
+		return _singleValue.resolveKey(SingleValueType.SINGLE_INSTANZ.getPath(), valueKey, SingleInstanzValue.class);
 	}
 
 	@Inject

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
@@ -2,10 +2,12 @@
 constant_add           = Add
 constant_cancel        = Cancel
 constant_children      = Children
+constant_filter        = Filter
 constant_instanz       = Instanz
 constant_key           = Key
 constant_name          = Name
 constant_no            = No
+constant_noInstanz     = No instanz chosen
 constant_parameterName = Parameter name
 constant_parent        = Parent
 constant_remove        = Remove
@@ -28,6 +30,7 @@ dialog_preferences_saveTitle = Save changes?
 
 dialog_save_text         = Should the changes be incorporated into the model?
 dialog_save_title        = Changed instanz
+dialog_selectInstanz_title = Choose instanz
 dialog_value_instanzSide = Instanz side
 dialog_value_usedName    = Name already used!
 dialog_value_valueSide   = Value side

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle.properties
@@ -13,6 +13,7 @@ constant_save          = Save
 constant_singleValue   = Single Value
 constant_type_boolean  = Boolean
 constant_type_float    = Float
+constant_type_instanz  = Instanz reference
 constant_type_integer  = Integer
 constant_type_string   = String
 constant_value         = Value

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
@@ -2,10 +2,12 @@
 constant_add           = Hinzuf\u00FCgen
 constant_cancel        = Abbrechen
 constant_children      = Kindelemente
+constant_filter        = Filter
 constant_instanz       = Instanz
 constant_key           = Schl\u00FCssel
 constant_name          = Name
 constant_no            = Nein
+constant_noInstanz     = Keine Instanz gew\u00E4hlt
 constant_parameterName = Parametername
 constant_parent        = Elternelement
 constant_remove        = Entfernen
@@ -28,6 +30,7 @@ dialog_preferences_saveTitle = \u00C4nderungen speichern?
 
 dialog_save_text         = Sollen die \u00C4nderungen ins Modell \u00FCbernommen werden?
 dialog_save_title        = Ge\u00E4nderte Instanz
+dialog_selectInstanz_title = Instanz w\u00E4hlen
 dialog_value_instanzSide = Instanzseite
 dialog_value_usedName    = Name bereits in Verwendung!
 dialog_value_valueSide   = Werteseite

--- a/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
+++ b/de.tonsias.basis.ui.i18n/OSGI-INF/l10n/bundle_de.properties
@@ -13,6 +13,7 @@ constant_save          = Speichern
 constant_singleValue   = Einzelwert
 constant_type_boolean  = Wahrheitswert
 constant_type_float    = Kommazahl
+constant_type_instanz  = Instanzverweis
 constant_type_integer  = Ganzzahl
 constant_type_string   = Text
 constant_value         = Wert

--- a/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
+++ b/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
@@ -15,6 +15,7 @@ public class Messages {
 	public String constant_singleValue;
 	public String constant_type_boolean;
 	public String constant_type_float;
+	public String constant_type_instanz;
 	public String constant_type_integer;
 	public String constant_type_string;
 	public String constant_value;

--- a/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
+++ b/de.tonsias.basis.ui.i18n/src/de/tonsias/basis/ui/i18n/Messages.java
@@ -4,10 +4,12 @@ public class Messages {
 	public String constant_add;
 	public String constant_cancel;
 	public String constant_children;
+	public String constant_filter;
 	public String constant_instanz;
 	public String constant_key;
 	public String constant_name;
 	public String constant_no;
+	public String constant_noInstanz;
 	public String constant_parameterName;
 	public String constant_parent;
 	public String constant_remove;
@@ -30,6 +32,8 @@ public class Messages {
 
 	public String dialog_save_text;
 	public String dialog_save_title;
+
+	public String dialog_selectInstanz_title;
 
 	public String dialog_value_instanzSide;
 	public String dialog_value_usedName;

--- a/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: de.tonsias.basis.ui.test
 Bundle-Version: 0.2.0.qualifier
 Require-Bundle: de.tonsias.basis.ui;bundle-version="0.2.0",
  de.tonsias.basis.ui.i18n;bundle-version="0.2.0",
+ de.tonsias.basis.logic;bundle-version="0.2.0",
  de.tonsias.basis.model;bundle-version="0.2.0",
  de.tonsias.basis.osgi;bundle-version="0.2.0",
  de.tonsias.basis.osgi.test;bundle-version="0.2.0",

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/InstanzSelectionDialogSystemTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/InstanzSelectionDialogSystemTest.java
@@ -1,0 +1,256 @@
+package de.tonsias.basis.ui.test.system;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TreeItem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tonsias.basis.logic.part.InstanzChoices;
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IEventBrokerBridge.Type;
+import de.tonsias.basis.osgi.test.ProductRuntime;
+import de.tonsias.basis.ui.i18n.Messages;
+import de.tonsias.basis.ui.widget.InstanzChooser;
+import de.tonsias.basis.ui.widget.InstanzSelectionDialog;
+
+/**
+ * The chooser on its own, for the two places that have no room to draw a tree
+ * where they stand: the Instanz View, which has one line per attribute, and the
+ * value column of the create dialog, which is a table cell.
+ * <p>
+ * Built the way JFace builds a dialog - {@code Window.create()} runs
+ * {@code createDialogArea} and {@code createButtonBar}, and nothing else
+ * happens before the user sees it. The widgets are then found on the shell and
+ * read the way a user would see them.
+ * </p>
+ * <p>
+ * It replaces a {@code Combo} holding every instanz of the model, flattened:
+ * usable in a test model, unusable in a real one, see
+ * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>.
+ * </p>
+ */
+public class InstanzSelectionDialogSystemTest {
+
+	private static Display _display;
+
+	private static Shell _shell;
+
+	private IInstanz _branch;
+
+	private IInstanz _leaf;
+
+	/** a branch next to the one below, so the filter has something it must hide */
+	private IInstanz _sibling;
+
+	private InstanzChoices _choices;
+
+	private Messages _messages;
+
+	private final List<Dialog> _built = new ArrayList<>();
+
+	@BeforeAll
+	static void beforeAll() {
+		_display = Display.getDefault();
+		_shell = new Shell(_display);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		if (_shell != null && !_shell.isDisposed()) {
+			_shell.dispose();
+		}
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		ProductRuntime.start();
+		// the runtime is shared by the whole bundle, so this test builds a branch of
+		// its own rather than reading whatever else is below the root
+		_branch = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		_leaf = ProductRuntime.instanzService().createInstanz(_branch.getOwnKey(), Type.SEND);
+		_sibling = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		_choices = new InstanzChoices(ProductRuntime.instanzService(), ProductRuntime.singleValueService(),
+				ProductRuntime.preferenceService());
+		_messages = messages();
+	}
+
+	@AfterEach
+	void afterEach() {
+		_built.forEach(Dialog::close);
+		_built.clear();
+		ProductRuntime.flushDeltas();
+	}
+
+	/** nothing chosen is no answer, so the dialog may not offer to give one */
+	@Test
+	void testCreate_withoutAPreselection_okIsDisabled() {
+		InstanzSelectionDialog dialog = built(new InstanzSelectionDialog(_shell, _choices.tree(), _messages, ""));
+
+		assertThat(okButton(dialog).isEnabled(), is(false));
+		assertThat(dialog.getSelectedKey(), is(""));
+	}
+
+	/**
+	 * Opened on a relation that already points somewhere, the dialog offers OK
+	 * straight away - keeping what is there must not need a second choice.
+	 */
+	@Test
+	void testCreate_withAPreselection_okIsEnabledAndTheTargetIsSelected() {
+		InstanzSelectionDialog dialog = built(
+				new InstanzSelectionDialog(_shell, _choices.tree(), _messages, _leaf.getOwnKey()));
+
+		assertThat(dialog.getChooser().getSelectedKey(), is(_leaf.getOwnKey()));
+		assertThat(okButton(dialog).isEnabled(), is(true));
+	}
+
+	/** a key the tree does not hold is no selection - a deleted target reads so */
+	@Test
+	void testCreate_withAPreselectionTheTreeDoesNotHold_okIsDisabled() {
+		InstanzSelectionDialog dialog = built(
+				new InstanzSelectionDialog(_shell, _choices.tree(), _messages, "no-such-key"));
+
+		assertThat(dialog.getChooser().getSelectedKey(), is(""));
+		assertThat(okButton(dialog).isEnabled(), is(false));
+	}
+
+	@Test
+	void testSelection_choosingAnInstanzEnablesOk() {
+		InstanzSelectionDialog dialog = built(new InstanzSelectionDialog(_shell, _choices.tree(), _messages, ""));
+
+		choose(dialog.getChooser(), _branch);
+
+		assertThat(okButton(dialog).isEnabled(), is(true));
+	}
+
+	/**
+	 * What the caller reads afterwards: the key is what a relation stores, the
+	 * label is what the caller puts on screen. Both are taken before OK closes the
+	 * dialog and disposes the tree they came from.
+	 */
+	@Test
+	void testOkPressed_handsBackTheKeyAndTheLabelOfTheChosenInstanz() {
+		InstanzSelectionDialog dialog = built(new InstanzSelectionDialog(_shell, _choices.tree(), _messages, ""));
+		choose(dialog.getChooser(), _leaf);
+
+		press(okButton(dialog));
+
+		assertThat(dialog.getSelectedKey(), is(_leaf.getOwnKey()));
+		// no MODEL_VIEW_TEXT value on this instanz, so it reads as itself
+		assertThat(dialog.getSelectedLabel(), is(_choices.labelOf(_leaf)));
+	}
+
+	/** the model is drawn as the tree it is, not flattened into a list */
+	@Test
+	void testCreate_showsTheModelAsATree() {
+		InstanzSelectionDialog dialog = built(new InstanzSelectionDialog(_shell, _choices.tree(), _messages, ""));
+
+		Choice branch = dialog.getChooser().root().find(_branch.getOwnKey()).orElseThrow();
+
+		assertThat(branch._children().stream().map(Choice::_key).toList(), hasItem(_leaf.getOwnKey()));
+	}
+
+	/** and the filter is what makes that tree usable once the model is large */
+	@Test
+	void testFilter_narrowsTheTreeToWhatIsNamed() {
+		InstanzSelectionDialog dialog = built(new InstanzSelectionDialog(_shell, _choices.tree(), _messages, ""));
+		InstanzChooser chooser = dialog.getChooser();
+
+		chooser.getFilterText().setText(_leaf.getOwnKey());
+
+		List<String> shown = visibleKeys(chooser);
+		assertThat("the match", shown, hasItem(_leaf.getOwnKey()));
+		assertThat("and the branch above it", shown, hasItem(_branch.getOwnKey()));
+		assertThat("but not a sibling branch", shown, not(hasItem(_sibling.getOwnKey())));
+	}
+
+	// ---------- building the dialog and finding its widgets ----------
+
+	private <D extends Dialog> D built(D dialog) {
+		dialog.create();
+		_built.add(dialog);
+		return dialog;
+	}
+
+	private Button okButton(Dialog dialog) {
+		return controls(dialog.getShell()).stream()//
+				.filter(Button.class::isInstance).map(Button.class::cast)//
+				.filter(button -> Integer.valueOf(IDialogConstants.OK_ID).equals(button.getData()))//
+				.findFirst()//
+				.orElseThrow(() -> new AssertionError("no OK button in " + dialog.getClass().getSimpleName()));
+	}
+
+	private void press(Button button) {
+		button.notifyListeners(SWT.Selection, new Event());
+	}
+
+	/**
+	 * Chooses an instanz the way a click does: JFace turns a click into a selection
+	 * on the viewer, and it is the viewer that tells the listener judging the OK
+	 * button.
+	 */
+	private void choose(InstanzChooser chooser, IInstanz instanz) {
+		Choice choice = chooser.root().find(instanz.getOwnKey())//
+				.orElseThrow(() -> new AssertionError("'" + instanz + "' is not in the tree"));
+		chooser.getViewer().setSelection(new StructuredSelection(choice), true);
+	}
+
+	private List<String> visibleKeys(InstanzChooser chooser) {
+		List<String> keys = new ArrayList<>();
+		collectKeys(chooser.getViewer().getTree().getItems(), keys);
+		return keys;
+	}
+
+	private void collectKeys(TreeItem[] items, List<String> keys) {
+		for (TreeItem item : items) {
+			if (item.getData() instanceof Choice choice) {
+				keys.add(choice._key());
+			}
+			collectKeys(item.getItems(), keys);
+		}
+	}
+
+	private List<Control> controls(Composite root) {
+		List<Control> all = new ArrayList<>();
+		for (Control child : root.getChildren()) {
+			all.add(child);
+			if (child instanceof Composite composite) {
+				all.addAll(controls(composite));
+			}
+		}
+		return all;
+	}
+
+	/**
+	 * The dialog puts these onto a shell title and a field placeholder and would
+	 * fail on a {@code null}. What they say is not what this test is about -
+	 * {@code TranslationCoverageTest} holds the real texts to their keys.
+	 */
+	private Messages messages() {
+		Messages messages = new Messages();
+		messages.constant_cancel = "Cancel";
+		messages.constant_filter = "Filter";
+		messages.dialog_selectInstanz_title = "Choose instanz";
+		return messages;
+	}
+}

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,9 +16,9 @@ import java.util.Set;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -25,6 +26,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.TreeItem;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
@@ -49,6 +52,7 @@ import de.tonsias.basis.ui.dialog.InstanzValueDialog;
 import de.tonsias.basis.ui.dialog.IntegerValueDialog;
 import de.tonsias.basis.ui.dialog.StringValueDialog;
 import de.tonsias.basis.ui.i18n.Messages;
+import de.tonsias.basis.ui.widget.InstanzChooser;
 
 /**
  * The value dialogs on a real {@link Display}, built the way JFace builds them:
@@ -397,14 +401,14 @@ public class ValueDialogSystemTest {
 
 	/**
 	 * A new relation opens on no selection, which is the one thing
-	 * {@link SingleInstanzValue#tryToSetValue} refuses - so OK may not be on offer
-	 * for it, the same rule the empty number field is held to.
+	 * {@link SingleInstanzValue#accepts} refuses - so OK may not be on offer for
+	 * it, the same rule the empty number field is held to.
 	 */
 	@Test
 	void testCreate_newInstanzValue_okIsDisabledWithoutASelection() {
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
 
-		assertThat(combo(dialog).getSelectionIndex(), is(-1));
+		assertThat(chooser(dialog).getSelectedKey(), is(""));
 		assertThat(okButton(dialog).isEnabled(), is(false));
 	}
 
@@ -413,20 +417,63 @@ public class ValueDialogSystemTest {
 	void testValueControl_choosingAnInstanzEnablesOk() {
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
 
-		choose(combo(dialog), _instanz);
+		choose(chooser(dialog), _instanz);
 
 		assertThat(okButton(dialog).isEnabled(), is(true));
 	}
 
-	/** every instanz of the model is on offer, the root included */
+	/**
+	 * Every instanz of the model is on offer, and it is offered where it sits: the
+	 * chooser draws the tree rather than a flat list of everything, which is what
+	 * keeps it usable once a model grows.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>
+	 */
 	@Test
-	void testCreate_newInstanzValue_offersTheInstanzenOfTheModel() {
+	void testCreate_newInstanzValue_offersTheModelAsATree() {
+		IInstanz child = ProductRuntime.instanzService().createInstanz(_instanz.getOwnKey(), Type.SEND);
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
 
-		List<String> items = List.of(combo(dialog).getItems());
+		Choice root = chooser(dialog).root();
 
-		assertThat(items, hasItem(_instanz.toString()));
-		assertThat("the root walks first", items.isEmpty(), is(false));
+		assertThat("the walk starts at the root", root._key(), is(ProductRuntime.ROOT));
+		assertThat(root.find(_instanz.getOwnKey()).orElseThrow()._children().stream().map(Choice::_key).toList(),
+				contains(child.getOwnKey()));
+	}
+
+	/**
+	 * The filter is the other half of the answer to a large model: typing narrows
+	 * the tree to what is named, and keeps the branch above a match so the match is
+	 * not hidden with its parent.
+	 *
+	 * @see <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>
+	 */
+	@Test
+	void testValueControl_theFilterNarrowsTheTreeAndKeepsThePathToAMatch() {
+		IInstanz child = ProductRuntime.instanzService().createInstanz(_instanz.getOwnKey(), Type.SEND);
+		IInstanz stranger = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+		InstanzChooser chooser = chooser(dialog);
+
+		chooser.getFilterText().setText(child.getOwnKey());
+
+		List<String> shown = visibleKeys(chooser);
+		assertThat("the match itself", shown, hasItem(child.getOwnKey()));
+		assertThat("and the branch leading to it", shown, hasItem(_instanz.getOwnKey()));
+		assertThat("but nothing else", shown, not(hasItem(stranger.getOwnKey())));
+	}
+
+	/** an empty filter is no filter - everything is back */
+	@Test
+	void testValueControl_clearingTheFilterShowsTheWholeTreeAgain() {
+		IInstanz stranger = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+		InstanzChooser chooser = chooser(dialog);
+
+		chooser.getFilterText().setText(_instanz.getOwnKey());
+		chooser.getFilterText().setText("");
+
+		assertThat(visibleKeys(chooser), hasItem(stranger.getOwnKey()));
 	}
 
 	/**
@@ -441,7 +488,8 @@ public class ValueDialogSystemTest {
 
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, value, _instanz, _messages));
 
-		assertThat(combo(dialog).getText(), is(target.toString()));
+		assertThat(chooser(dialog).getSelectedKey(), is(target.getOwnKey()));
+		assertThat(chooser(dialog).getSelectedLabel(), is(target.toString()));
 		assertThat(okButton(dialog).isEnabled(), is(true));
 	}
 
@@ -454,7 +502,7 @@ public class ValueDialogSystemTest {
 				_instanz.getOwnKey(), "stored reference", first.getOwnKey(), Type.SEND);
 
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, value, _instanz, _messages));
-		choose(combo(dialog), second);
+		choose(chooser(dialog), second);
 		press(okButton(dialog));
 
 		assertThat(value.getValue(), is(second.getOwnKey()));
@@ -468,11 +516,13 @@ public class ValueDialogSystemTest {
 		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
 
 		nameText(dialog).setText("points at");
-		choose(combo(dialog), target);
+		choose(chooser(dialog), target);
 		press(okButton(dialog));
 
 		assertThat(dialog.getSingleValue().getValue(), is(target.getOwnKey()));
 		assertThat(dialog.getSingleValue().getConnectedInstanzKeys(), contains(_instanz.getOwnKey()));
+		assertThat("and the target records the other end",
+				target.getReferencingValueKeys(), hasItem(dialog.getSingleValue().getOwnKey()));
 	}
 
 	// ---------- what the model would do ----------
@@ -541,25 +591,44 @@ public class ValueDialogSystemTest {
 		return texts(dialog).get(1);
 	}
 
-	/** the combo box an {@link InstanzValueDialog} chooses its value in */
-	private Combo combo(Dialog dialog) {
+	/** the tree an {@link InstanzValueDialog} chooses its value in */
+	private InstanzChooser chooser(Dialog dialog) {
 		return controls(dialog.getShell()).stream()//
-				.filter(Combo.class::isInstance).map(Combo.class::cast)//
+				.filter(InstanzChooser.class::isInstance).map(InstanzChooser.class::cast)//
 				.findFirst()//
-				.orElseThrow(() -> new AssertionError("no combo in " + dialog.getClass().getSimpleName()));
+				.orElseThrow(() -> new AssertionError("no chooser in " + dialog.getClass().getSimpleName()));
 	}
 
 	/**
-	 * Chooses an instanz the way a click does. {@code Combo.select} moves the
-	 * selection but fires nothing, so the listener that judges the OK button would
-	 * never run.
+	 * Chooses an instanz the way a click does: JFace turns a click into a selection
+	 * on the viewer, and it is the viewer that tells the listener judging the OK
+	 * button. Selecting the tree item alone would move the highlight and say
+	 * nothing.
 	 */
-	private void choose(Combo combo, IInstanz instanz) {
-		// no MODEL_VIEW_TEXT value on these instanzen, so they read as themselves
-		int index = List.of(combo.getItems()).indexOf(instanz.toString());
-		assertThat("'" + instanz + "' among " + List.of(combo.getItems()), index, greaterThanOrEqualTo(0));
-		combo.select(index);
-		combo.notifyListeners(SWT.Selection, new Event());
+	private void choose(InstanzChooser chooser, IInstanz instanz) {
+		Choice choice = chooser.root().find(instanz.getOwnKey())//
+				.orElseThrow(() -> new AssertionError("'" + instanz + "' is not in the tree"));
+		chooser.getViewer().setSelection(new StructuredSelection(choice), true);
+	}
+
+	/**
+	 * The keys the tree is showing right now - what the filter left of it. Read off
+	 * the SWT items rather than off the model, because that is where the filter has
+	 * had its say.
+	 */
+	private List<String> visibleKeys(InstanzChooser chooser) {
+		List<String> keys = new ArrayList<>();
+		collectKeys(chooser.getViewer().getTree().getItems(), keys);
+		return keys;
+	}
+
+	private void collectKeys(TreeItem[] items, List<String> keys) {
+		for (TreeItem item : items) {
+			if (item.getData() instanceof Choice choice) {
+				keys.add(choice._key());
+			}
+			collectKeys(item.getItems(), keys);
+		}
 	}
 
 	/**
@@ -623,6 +692,7 @@ public class ValueDialogSystemTest {
 	private Messages messages() {
 		Messages messages = new Messages();
 		messages.constant_cancel = "Cancel";
+		messages.constant_filter = "Filter";
 		messages.constant_key = "Key";
 		messages.constant_name = "Name";
 		messages.constant_singleValue = "Value";

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/system/ValueDialogSystemTest.java
@@ -2,18 +2,22 @@ package de.tonsias.basis.ui.test.system;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -32,6 +36,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -40,6 +45,7 @@ import de.tonsias.basis.osgi.test.ProductRuntime;
 import de.tonsias.basis.ui.dialog.AValueDialog;
 import de.tonsias.basis.ui.dialog.BooleanValueDialog;
 import de.tonsias.basis.ui.dialog.FloatValueDialog;
+import de.tonsias.basis.ui.dialog.InstanzValueDialog;
 import de.tonsias.basis.ui.dialog.IntegerValueDialog;
 import de.tonsias.basis.ui.dialog.StringValueDialog;
 import de.tonsias.basis.ui.i18n.Messages;
@@ -387,6 +393,88 @@ public class ValueDialogSystemTest {
 		assertThat(dialog.getSingleValue().getConnectedInstanzKeys(), contains(_instanz.getOwnKey()));
 	}
 
+	// ---------- the relation, which is chosen rather than typed ----------
+
+	/**
+	 * A new relation opens on no selection, which is the one thing
+	 * {@link SingleInstanzValue#tryToSetValue} refuses - so OK may not be on offer
+	 * for it, the same rule the empty number field is held to.
+	 */
+	@Test
+	void testCreate_newInstanzValue_okIsDisabledWithoutASelection() {
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+
+		assertThat(combo(dialog).getSelectionIndex(), is(-1));
+		assertThat(okButton(dialog).isEnabled(), is(false));
+	}
+
+	/** and is on offer as soon as one is chosen */
+	@Test
+	void testValueControl_choosingAnInstanzEnablesOk() {
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+
+		choose(combo(dialog), _instanz);
+
+		assertThat(okButton(dialog).isEnabled(), is(true));
+	}
+
+	/** every instanz of the model is on offer, the root included */
+	@Test
+	void testCreate_newInstanzValue_offersTheInstanzenOfTheModel() {
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+
+		List<String> items = List.of(combo(dialog).getItems());
+
+		assertThat(items, hasItem(_instanz.toString()));
+		assertThat("the root walks first", items.isEmpty(), is(false));
+	}
+
+	/**
+	 * A dialog opened on a stored relation shows where it points, so the user is
+	 * not asked to choose again to keep what is already there.
+	 */
+	@Test
+	void testCreate_existingInstanzValue_preselectsTheTarget() {
+		IInstanz target = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		SingleInstanzValue value = ProductRuntime.singleValueService().createNew(SingleInstanzValue.class,
+				_instanz.getOwnKey(), "stored reference", target.getOwnKey(), Type.SEND);
+
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, value, _instanz, _messages));
+
+		assertThat(combo(dialog).getText(), is(target.toString()));
+		assertThat(okButton(dialog).isEnabled(), is(true));
+	}
+
+	/** what OK leaves behind is the key of the chosen instanz, not its label */
+	@Test
+	void testOkPressed_existingInstanzValue_writesTheChosenKeyBack() {
+		IInstanz first = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		IInstanz second = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		SingleInstanzValue value = ProductRuntime.singleValueService().createNew(SingleInstanzValue.class,
+				_instanz.getOwnKey(), "stored reference", first.getOwnKey(), Type.SEND);
+
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, value, _instanz, _messages));
+		choose(combo(dialog), second);
+		press(okButton(dialog));
+
+		assertThat(value.getValue(), is(second.getOwnKey()));
+		assertThat(ProductRuntime.instanzService().resolveInstanzValue(value), is(Optional.of(second)));
+	}
+
+	/** and a new one is created pointing at it */
+	@Test
+	void testOkPressed_newInstanzValue_createsItPointingAtTheChosenInstanz() {
+		IInstanz target = ProductRuntime.instanzService().createInstanz(ProductRuntime.ROOT, Type.SEND);
+		InstanzValueDialog dialog = built(new InstanzValueDialog(_shell, _instanz, _messages));
+
+		nameText(dialog).setText("points at");
+		choose(combo(dialog), target);
+		press(okButton(dialog));
+
+		assertThat(dialog.getSingleValue().getValue(), is(target.getOwnKey()));
+		assertThat(dialog.getSingleValue().getConnectedInstanzKeys(), contains(_instanz.getOwnKey()));
+	}
+
 	// ---------- what the model would do ----------
 
 	/**
@@ -438,12 +526,40 @@ public class ValueDialogSystemTest {
 	 * the test onto the wrong widget.
 	 */
 	private Text valueText(Dialog dialog) {
-		return texts(dialog).get(2);
+		List<Text> texts = texts(dialog);
+		assertThat("key, name and value", texts, hasSize(3));
+		return texts.get(2);
 	}
 
-	/** the name field, the second of the three - see {@link #valueText(Dialog)} */
+	/**
+	 * The name field, the second one every dialog has - see
+	 * {@link #valueText(Dialog)}. It is read off the shorter list too, because a
+	 * dialog whose value is chosen rather than typed has no third {@link Text} at
+	 * all.
+	 */
 	private Text nameText(Dialog dialog) {
 		return texts(dialog).get(1);
+	}
+
+	/** the combo box an {@link InstanzValueDialog} chooses its value in */
+	private Combo combo(Dialog dialog) {
+		return controls(dialog.getShell()).stream()//
+				.filter(Combo.class::isInstance).map(Combo.class::cast)//
+				.findFirst()//
+				.orElseThrow(() -> new AssertionError("no combo in " + dialog.getClass().getSimpleName()));
+	}
+
+	/**
+	 * Chooses an instanz the way a click does. {@code Combo.select} moves the
+	 * selection but fires nothing, so the listener that judges the OK button would
+	 * never run.
+	 */
+	private void choose(Combo combo, IInstanz instanz) {
+		// no MODEL_VIEW_TEXT value on these instanzen, so they read as themselves
+		int index = List.of(combo.getItems()).indexOf(instanz.toString());
+		assertThat("'" + instanz + "' among " + List.of(combo.getItems()), index, greaterThanOrEqualTo(0));
+		combo.select(index);
+		combo.notifyListeners(SWT.Selection, new Event());
 	}
 
 	/**
@@ -474,11 +590,15 @@ public class ValueDialogSystemTest {
 		button.notifyListeners(SWT.Selection, new Event());
 	}
 
+	/**
+	 * Key and name come from {@code AValueDialog} and are there in every dialog; a
+	 * third one is the value field of the dialogs that are typed into.
+	 */
 	private List<Text> texts(Dialog dialog) {
 		List<Text> texts = controls(dialog.getShell()).stream()//
 				.filter(Text.class::isInstance).map(Text.class::cast)//
 				.toList();
-		assertThat("key, name and value", texts, hasSize(3));
+		assertThat("key and name", texts, hasSize(greaterThanOrEqualTo(2)));
 		return texts;
 	}
 

--- a/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
+++ b/de.tonsias.basis.ui.test/src/de/tonsias/basis/ui/test/util/MessagesUtilTest.java
@@ -21,6 +21,7 @@ class MessagesUtilTest {
 		messages.constant_type_integer = "Integer";
 		messages.constant_type_boolean = "Boolean";
 		messages.constant_type_float = "Float";
+		messages.constant_type_instanz = "Instanz reference";
 		messages.pref_currentKey = "Current key";
 		messages.pref_modelViewText = "Model view text";
 		messages.pref_enableValues = "Enable values";
@@ -36,6 +37,8 @@ class MessagesUtilTest {
 		assertEquals("Integer", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_INTEGER));
 		assertEquals("Boolean", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_BOOLEAN));
 		assertEquals("Float", MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_FLOAT));
+		assertEquals("Instanz reference",
+				MessagesUtil.getSingleValueTypeLabel(messages, SingleValueType.SINGLE_INSTANZ));
 	}
 
 	/**

--- a/de.tonsias.basis.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: de.tonsias.basis.ui;singleton:=true
 Bundle-Version: 0.2.0.qualifier
 Export-Package: de.tonsias.basis.ui.dialog;x-friends:="de.tonsias.basis
  .ui.test",
- de.tonsias.basis.ui.util;x-friends:="de.tonsias.basis.ui.test"
+ de.tonsias.basis.ui.util;x-friends:="de.tonsias.basis.ui.test",
+ de.tonsias.basis.ui.widget;x-friends:="de.tonsias.basis.ui.test"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.jface;bundle-version="3.33.0",
  org.eclipse.e4.core.di;bundle-version="1.9.300",

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/CreateInstanzDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/CreateInstanzDialog.java
@@ -12,12 +12,14 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
+import org.eclipse.jface.viewers.DialogCellEditor;
 import org.eclipse.jface.viewers.EditingSupport;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.TextCellEditor;
 import org.eclipse.jface.widgets.ButtonFactory;
 import org.eclipse.jface.widgets.CompositeFactory;
+import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
@@ -36,6 +38,7 @@ import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.ui.i18n.Messages;
 import de.tonsias.basis.ui.util.MessagesUtil;
+import de.tonsias.basis.ui.widget.InstanzSelectionDialog;
 
 public class CreateInstanzDialog extends Dialog {
 
@@ -109,7 +112,9 @@ public class CreateInstanzDialog extends Dialog {
 				tRec -> MessagesUtil.getSingleValueTypeLabel(_messages, tRec.type), //
 				getEditingSupport(//
 						(element, value) -> {
-							element.type = SingleValueType.values()[(int) value];
+							// the logic drops a value the new type would not take with it, so the row
+							// never carries text under a type that stores a key
+							_logic.setType(element, SingleValueType.values()[(int) value]);
 							_viewer.update(element, null);
 						}, //
 						element -> Arrays.asList(SingleValueType.values()).indexOf(element.type), //
@@ -131,18 +136,47 @@ public class CreateInstanzDialog extends Dialog {
 						element -> element.parameterName, //
 						element -> new TextCellEditor(_viewer.getTable())));
 
-		createColumn(_messages.constant_value, 200, tRec -> tRec.value.toString(), //
+		// the one column whose editor depends on the row: a relation is chosen from the
+		// tree the value dialog offers, not typed as a raw key, see
+		// https://github.com/Tobias-Bonsack/Tonsias/issues/75
+		createColumn(_messages.constant_value, 200, tRec -> _logic.valueLabel(tRec), //
 				getEditingSupport(//
 						(element, value) -> {
 							element.value = value;
 							_viewer.update(element, null);
 						}, //
 						element -> element.value, //
-						element -> new TextCellEditor(_viewer.getTable())));
+						element -> element.type == SingleValueType.SINGLE_INSTANZ ? instanzCellEditor()
+								: new TextCellEditor(_viewer.getTable())));
 
 
 		_viewer.setContentProvider(ArrayContentProvider.getInstance());
 		_viewer.setInput(_logic.getInput());
+	}
+
+	/**
+	 * The cell editor of a relation: a cell that opens {@link InstanzSelectionDialog}
+	 * rather than one that is typed into. What it keeps is the key of the chosen
+	 * instanz, and what it shows is the label - the same pair the Instanz View
+	 * shows on its button.
+	 */
+	private CellEditor instanzCellEditor() {
+		return new DialogCellEditor(_viewer.getTable()) {
+
+			@Override
+			protected Object openDialogBox(Control cellEditorWindow) {
+				var dialog = new InstanzSelectionDialog(cellEditorWindow.getShell(), _logic.instanzChoices().tree(),
+						_messages, String.valueOf(getValue()));
+				// cancelling keeps what the cell held - the editor writes back whatever comes
+				// out of here, so handing back null would empty the cell
+				return dialog.open() == Window.OK ? dialog.getSelectedKey() : getValue();
+			}
+
+			@Override
+			protected void updateContents(Object value) {
+				super.updateContents(_logic.instanzChoices().labelOf(String.valueOf(value)).orElse(""));
+			}
+		};
 	}
 
 	private void createColumn(String title, int width, IColumnLabelProvider provider, EditingSupport editingSupport) {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/InstanzValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/InstanzValueDialog.java
@@ -1,41 +1,39 @@
 package de.tonsias.basis.ui.dialog;
 
-import java.util.List;
-
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
 import de.tonsias.basis.logic.part.InstanzChoices;
-import de.tonsias.basis.logic.part.InstanzChoices.Choice;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.ui.i18n.Messages;
+import de.tonsias.basis.ui.widget.InstanzChooser;
 
 /**
- * The dialog of a relation. Its value is not typed but chosen: the combo box
- * holds the instanzen of the model, and what the value stores is the key behind
- * the selected entry.
+ * The dialog of a relation. Its value is not typed but chosen: the tree holds
+ * the instanzen of the model, and what the value stores is the key behind the
+ * selected entry.
  * <p>
  * {@link BooleanValueDialog} is the shape this follows - the other one whose
- * value control is not a {@code Text}.
+ * value control is not a {@code Text}. The chooser sits in the dialog itself
+ * rather than behind a button: this is already a dialog, and one that opens
+ * another to fill a single field would ask for two OKs for one decision.
  * </p>
  */
-public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, Combo> {
+public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, InstanzChooser> {
 
-	/** in the order of the combo box entries, so the index maps onto the key */
-	private List<Choice> _choices = List.of();
+	private final Messages _dialogMessages;
 
 	public InstanzValueDialog(Shell parentShell, SingleInstanzValue instanzValue, IInstanz instanz,
 			Messages messages) {
 		super(parentShell, instanzValue, instanz, messages);
+		_dialogMessages = messages;
 	}
 
 	public InstanzValueDialog(Shell parentShell, IInstanz instanz, Messages messages) {
@@ -48,31 +46,24 @@ public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, Combo> 
 	 *                    points at an instanz the walk did not reach
 	 */
 	@Override
-	protected Combo createValueControl(Composite composite, String valueString) {
-		_choices = new InstanzChoices(_iService, _sVService, OsgiUtil.getService(IBasicPreferenceService.class))
-				.choices();
+	protected InstanzChooser createValueControl(Composite composite, String valueString) {
+		InstanzChoices choices = new InstanzChoices(_iService, _sVService,
+				OsgiUtil.getService(IBasicPreferenceService.class));
 
-		Combo combo = new Combo(composite, SWT.READ_ONLY);
-		combo.setItems(_choices.stream().map(Choice::_label).toArray(String[]::new));
-		GridDataFactory.fillDefaults().grab(true, false).applyTo(combo);
-
-		for (int i = 0; i < _choices.size(); i++) {
-			if (_choices.get(i)._key().equals(valueString)) {
-				combo.select(i);
-				break;
-			}
-		}
-		return combo;
+		InstanzChooser chooser = new InstanzChooser(composite, choices.tree(), _dialogMessages.constant_filter);
+		GridDataFactory.fillDefaults().grab(true, true).hint(SWT.DEFAULT, 250).applyTo(chooser);
+		chooser.setSelectedKey(valueString);
+		return chooser;
 	}
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		Control control = super.createDialogArea(parent);
 
-		// a read-only combo is never typed into, so it is the selection that has to put
-		// the question to refreshOkButton - the same job the modify listener of the
+		// a tree is never typed into, so it is the selection that has to put the
+		// question to refreshOkButton - the same job the modify listener of the
 		// numeric dialogs does
-		_valueControl.addSelectionListener(SelectionListener.widgetSelectedAdapter(event -> refreshOkButton()));
+		_valueControl.onSelectionChanged(this::refreshOkButton);
 
 		return control;
 	}
@@ -84,8 +75,7 @@ public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, Combo> 
 	 */
 	@Override
 	protected Object getEnteredValue() {
-		int index = _valueControl.getSelectionIndex();
-		return index < 0 ? "" : _choices.get(index)._key();
+		return _valueControl.getSelectedKey();
 	}
 
 	@Override
@@ -95,8 +85,8 @@ public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, Combo> 
 
 	/**
 	 * The rule of the type itself, asked rather than restated, so the button cannot
-	 * offer what {@link SingleInstanzValue#tryToSetValue} would then discard - the
-	 * empty selection a new reference opens on included.
+	 * offer what {@link SingleInstanzValue#tryToSetValue} would then take as
+	 * "points nowhere" - the empty selection a new reference opens on included.
 	 */
 	@Override
 	protected boolean isValueAcceptable() {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/InstanzValueDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/dialog/InstanzValueDialog.java
@@ -1,0 +1,110 @@
+package de.tonsias.basis.ui.dialog;
+
+import java.util.List;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+
+import de.tonsias.basis.logic.part.InstanzChoices;
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
+import de.tonsias.basis.model.enums.SingleValueType;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
+import de.tonsias.basis.model.interfaces.IInstanz;
+import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
+import de.tonsias.basis.osgi.util.OsgiUtil;
+import de.tonsias.basis.ui.i18n.Messages;
+
+/**
+ * The dialog of a relation. Its value is not typed but chosen: the combo box
+ * holds the instanzen of the model, and what the value stores is the key behind
+ * the selected entry.
+ * <p>
+ * {@link BooleanValueDialog} is the shape this follows - the other one whose
+ * value control is not a {@code Text}.
+ * </p>
+ */
+public class InstanzValueDialog extends AValueDialog<SingleInstanzValue, Combo> {
+
+	/** in the order of the combo box entries, so the index maps onto the key */
+	private List<Choice> _choices = List.of();
+
+	public InstanzValueDialog(Shell parentShell, SingleInstanzValue instanzValue, IInstanz instanz,
+			Messages messages) {
+		super(parentShell, instanzValue, instanz, messages);
+	}
+
+	public InstanzValueDialog(Shell parentShell, IInstanz instanz, Messages messages) {
+		this(parentShell, null, instanz, messages);
+	}
+
+	/**
+	 * @param valueString the stored target key, empty for a new reference - the
+	 *                    matching entry is preselected, and nothing is when the key
+	 *                    points at an instanz the walk did not reach
+	 */
+	@Override
+	protected Combo createValueControl(Composite composite, String valueString) {
+		_choices = new InstanzChoices(_iService, _sVService, OsgiUtil.getService(IBasicPreferenceService.class))
+				.choices();
+
+		Combo combo = new Combo(composite, SWT.READ_ONLY);
+		combo.setItems(_choices.stream().map(Choice::_label).toArray(String[]::new));
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(combo);
+
+		for (int i = 0; i < _choices.size(); i++) {
+			if (_choices.get(i)._key().equals(valueString)) {
+				combo.select(i);
+				break;
+			}
+		}
+		return combo;
+	}
+
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Control control = super.createDialogArea(parent);
+
+		// a read-only combo is never typed into, so it is the selection that has to put
+		// the question to refreshOkButton - the same job the modify listener of the
+		// numeric dialogs does
+		_valueControl.addSelectionListener(SelectionListener.widgetSelectedAdapter(event -> refreshOkButton()));
+
+		return control;
+	}
+
+	/**
+	 * The key behind the selection, and the empty string while there is none -
+	 * which is what a new dialog opens on and what {@link #isValueAcceptable()}
+	 * refuses.
+	 */
+	@Override
+	protected Object getEnteredValue() {
+		int index = _valueControl.getSelectionIndex();
+		return index < 0 ? "" : _choices.get(index)._key();
+	}
+
+	@Override
+	protected Class<SingleInstanzValue> getValueClass() {
+		return SingleInstanzValue.class;
+	}
+
+	/**
+	 * The rule of the type itself, asked rather than restated, so the button cannot
+	 * offer what {@link SingleInstanzValue#tryToSetValue} would then discard - the
+	 * empty selection a new reference opens on included.
+	 */
+	@Override
+	protected boolean isValueAcceptable() {
+		return SingleInstanzValue.accepts((String) getEnteredValue());
+	}
+
+	@Override
+	SingleValueType getType() {
+		return SingleValueType.SINGLE_INSTANZ;
+	}
+}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
@@ -2,6 +2,7 @@ package de.tonsias.basis.ui.part;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 
@@ -22,6 +23,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
@@ -33,15 +35,19 @@ import org.eclipse.swt.widgets.Text;
 
 import com.google.common.collect.BiMap;
 
+import de.tonsias.basis.logic.part.InstanzChoices;
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
 import de.tonsias.basis.logic.part.InstanzViewLogic;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.model.interfaces.ISingleValue;
+import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
 import de.tonsias.basis.osgi.intf.IEventBrokerBridge;
 import de.tonsias.basis.osgi.intf.IInstanzService;
 import de.tonsias.basis.osgi.intf.ISingleValueService;
 import de.tonsias.basis.osgi.intf.non.service.InstanzEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
+import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.ui.i18n.Messages;
 import de.tonsias.basis.ui.util.MessagesUtil;
 import jakarta.annotation.PostConstruct;
@@ -213,8 +219,25 @@ public class InstanzView {
 					.create(typeGroup);
 			check.setSelection(Boolean.TRUE.equals(singleValue.getValue()));
 			check.addSelectionListener(SelectionListener
-					.widgetSelectedAdapter(event -> onSingleValueSelect(singleValue, check)));
+					.widgetSelectedAdapter(event -> onSingleValueSelect(singleValue, check.getSelection(), check)));
 			control = check;
+			break;
+		case SINGLE_INSTANZ:
+			// a relation is chosen, not typed: the entries are the instanzen of the model
+			// and what travels to the job is the key behind the selected one
+			List<Choice> choices = instanzChoices().choices();
+			Combo combo = new Combo(typeGroup, SWT.READ_ONLY);
+			combo.setItems(choices.stream().map(Choice::_label).toArray(String[]::new));
+			GridDataFactory.fillDefaults().grab(true, false).applyTo(combo);
+			for (int i = 0; i < choices.size(); i++) {
+				if (choices.get(i)._key().equals(singleValue.getValue())) {
+					combo.select(i);
+					break;
+				}
+			}
+			combo.addSelectionListener(SelectionListener.widgetSelectedAdapter(
+					event -> onSingleValueSelect(singleValue, choices.get(combo.getSelectionIndex())._key(), combo)));
+			control = combo;
 			break;
 		default:
 			// without a widget the listener below would fail on null - a new type has to
@@ -276,18 +299,30 @@ public class InstanzView {
 	}
 
 	/**
-	 * The check box counterpart of {@link #onSingleValueModify} - a selection
-	 * carries its state on the widget instead of in the event, and the value goes
-	 * to the job as a {@link Boolean} rather than as text.
+	 * The counterpart of {@link #onSingleValueModify} for the controls a value is
+	 * chosen in rather than typed into: the check box and the combo box of a
+	 * relation. What they hold sits on the widget instead of in the event, so the
+	 * caller reads it out and hands it on - a {@link Boolean} for the one, the key
+	 * of the chosen instanz for the other.
 	 */
-	private void onSingleValueSelect(ISingleValue<?> singleValue, Button check) {
+	private void onSingleValueSelect(ISingleValue<?> singleValue, Object newValue, Control control) {
 		if (_logic.isInDelete(singleValue)) {
 			return;
 		}
 
-		check.setBackground(check.getDisplay().getSystemColor(SWT.COLOR_GREEN));
-		_logic.createModifySvJob(singleValue.getOwnKey(), check.getSelection());
+		control.setBackground(control.getDisplay().getSystemColor(SWT.COLOR_GREEN));
+		_logic.createModifySvJob(singleValue.getOwnKey(), newValue);
 		_part.setDirty(true);
+	}
+
+	/**
+	 * The instanzen a relation can point at. Built per call rather than kept: the
+	 * model changes under the view, and a stale list would offer instanzen that are
+	 * gone and hide the ones just made.
+	 */
+	private InstanzChoices instanzChoices() {
+		return new InstanzChoices(_instanzService, _singleService,
+				OsgiUtil.getService(IBasicPreferenceService.class));
 	}
 
 	private void createSingleValueNameText(Group parent, ISingleValue<?> singleValue, String parameterName,

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/InstanzView.java
@@ -2,7 +2,6 @@ package de.tonsias.basis.ui.part;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 
@@ -15,6 +14,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.widgets.ButtonFactory;
 import org.eclipse.jface.widgets.LabelFactory;
 import org.eclipse.jface.widgets.TextFactory;
+import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
@@ -23,7 +23,6 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
@@ -36,7 +35,6 @@ import org.eclipse.swt.widgets.Text;
 import com.google.common.collect.BiMap;
 
 import de.tonsias.basis.logic.part.InstanzChoices;
-import de.tonsias.basis.logic.part.InstanzChoices.Choice;
 import de.tonsias.basis.logic.part.InstanzViewLogic;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -50,6 +48,7 @@ import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
 import de.tonsias.basis.osgi.util.OsgiUtil;
 import de.tonsias.basis.ui.i18n.Messages;
 import de.tonsias.basis.ui.util.MessagesUtil;
+import de.tonsias.basis.ui.widget.InstanzSelectionDialog;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
@@ -223,21 +222,16 @@ public class InstanzView {
 			control = check;
 			break;
 		case SINGLE_INSTANZ:
-			// a relation is chosen, not typed: the entries are the instanzen of the model
-			// and what travels to the job is the key behind the selected one
-			List<Choice> choices = instanzChoices().choices();
-			Combo combo = new Combo(typeGroup, SWT.READ_ONLY);
-			combo.setItems(choices.stream().map(Choice::_label).toArray(String[]::new));
-			GridDataFactory.fillDefaults().grab(true, false).applyTo(combo);
-			for (int i = 0; i < choices.size(); i++) {
-				if (choices.get(i)._key().equals(singleValue.getValue())) {
-					combo.select(i);
-					break;
-				}
-			}
-			combo.addSelectionListener(SelectionListener.widgetSelectedAdapter(
-					event -> onSingleValueSelect(singleValue, choices.get(combo.getSelectionIndex())._key(), combo)));
-			control = combo;
+			// a relation is chosen, not typed. The view has one line per attribute, which
+			// is no room for a tree, so the button says where the relation points and
+			// opens the chooser
+			Button choose = ButtonFactory.newButton(SWT.PUSH)//
+					.text(targetLabel(String.valueOf(singleValue.getValue())))//
+					.layoutData(GridDataFactory.fillDefaults().grab(true, false).create())//
+					.create(typeGroup);
+			choose.addSelectionListener(
+					SelectionListener.widgetSelectedAdapter(event -> chooseTarget(singleValue, choose)));
+			control = choose;
 			break;
 		default:
 			// without a widget the listener below would fail on null - a new type has to
@@ -316,8 +310,33 @@ public class InstanzView {
 	}
 
 	/**
+	 * Opens the chooser on the tree as it is right now and hands the chosen key on
+	 * the way the check box hands on its state. Cancelling leaves the relation
+	 * where it points - the button is not a change in itself.
+	 */
+	private void chooseTarget(ISingleValue<?> singleValue, Button button) {
+		InstanzSelectionDialog dialog = new InstanzSelectionDialog(button.getShell(), instanzChoices().tree(),
+				_messages, String.valueOf(singleValue.getValue()));
+		if (dialog.open() != Window.OK) {
+			return;
+		}
+
+		button.setText(dialog.getSelectedLabel());
+		onSingleValueSelect(singleValue, dialog.getSelectedKey(), button);
+	}
+
+	/**
+	 * How the instanz a relation points at reads. A relation pointing nowhere says
+	 * so in so many words rather than sitting there as an empty button - and so
+	 * does one whose target the walk did not reach.
+	 */
+	private String targetLabel(String targetKey) {
+		return instanzChoices().labelOf(targetKey).orElse(_messages.constant_noInstanz);
+	}
+
+	/**
 	 * The instanzen a relation can point at. Built per call rather than kept: the
-	 * model changes under the view, and a stale list would offer instanzen that are
+	 * model changes under the view, and a stale tree would offer instanzen that are
 	 * gone and hide the ones just made.
 	 */
 	private InstanzChoices instanzChoices() {

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/part/ModelView.java
@@ -32,6 +32,7 @@ import org.osgi.service.event.Event;
 import de.tonsias.basis.model.enums.SingleValueType;
 import de.tonsias.basis.model.impl.value.SingleBooleanValue;
 import de.tonsias.basis.model.impl.value.SingleFloatValue;
+import de.tonsias.basis.model.impl.value.SingleInstanzValue;
 import de.tonsias.basis.model.impl.value.SingleIntegerValue;
 import de.tonsias.basis.model.impl.value.SingleStringValue;
 import de.tonsias.basis.model.interfaces.IInstanz;
@@ -50,6 +51,7 @@ import de.tonsias.basis.osgi.intf.non.service.PreferenceEventConstants;
 import de.tonsias.basis.osgi.intf.non.service.SingleValueEventConstants;
 import de.tonsias.basis.ui.dialog.BooleanValueDialog;
 import de.tonsias.basis.ui.dialog.FloatValueDialog;
+import de.tonsias.basis.ui.dialog.InstanzValueDialog;
 import de.tonsias.basis.ui.dialog.IntegerValueDialog;
 import de.tonsias.basis.ui.dialog.StringValueDialog;
 import de.tonsias.basis.ui.handler.CreateInstanzOperation;
@@ -311,6 +313,31 @@ public class ModelView {
 				int open = dialog.open();
 				if (open == Window.OK) {
 					SingleFloatValue singleValue = dialog.getSingleValue();
+					new TreeNodeWrapper(singleValue, parent);
+					_treeViewer.refresh(parent);
+				}
+
+			}
+		});
+
+		MenuItem createInstanzValueItem = new MenuItem(singleValueMenu, SWT.None);
+		createInstanzValueItem.setText(_messages.constant_type_instanz);
+
+		createInstanzValueItem.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				TreeItem[] selection = tree.getSelection();
+				if (selection.length != 1) {
+					return;
+				}
+
+				TreeNodeWrapper parent = (TreeNodeWrapper) selection[0].getData();
+				IInstanz parentObject = (IInstanz) parent.getObject();
+
+				InstanzValueDialog dialog = new InstanzValueDialog(new Shell(), parentObject, _messages);
+				int open = dialog.open();
+				if (open == Window.OK) {
+					SingleInstanzValue singleValue = dialog.getSingleValue();
 					new TreeNodeWrapper(singleValue, parent);
 					_treeViewer.refresh(parent);
 				}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/provider/TreeLabelProvider.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/provider/TreeLabelProvider.java
@@ -1,13 +1,10 @@
 package de.tonsias.basis.ui.provider;
 
-import java.util.Optional;
-
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.swt.graphics.Image;
 
-import de.tonsias.basis.model.enums.SingleValueType;
-import de.tonsias.basis.model.impl.value.SingleStringValue;
+import de.tonsias.basis.logic.part.InstanzChoices;
 import de.tonsias.basis.model.interfaces.IInstanz;
 import de.tonsias.basis.model.interfaces.IObject;
 import de.tonsias.basis.osgi.intf.IBasicPreferenceService;
@@ -23,6 +20,8 @@ public class TreeLabelProvider implements ILabelProvider {
 	IInstanzService _instanzService = OsgiUtil.getService(IInstanzService.class);
 
 	ISingleValueService _singleServise = OsgiUtil.getService(ISingleValueService.class);
+
+	InstanzChoices _choices = new InstanzChoices(_instanzService, _singleServise, _prefService);
 
 	@Override
 	public void addListener(ILabelProviderListener listener) {
@@ -54,21 +53,19 @@ public class TreeLabelProvider implements ILabelProvider {
 		return null;
 	}
 
+	/**
+	 * Values read as themselves; an instanz reads by the rule in
+	 * {@link InstanzChoices#labelOf(IInstanz)}, which the combo box of a relation is
+	 * filled from as well - the same instanz has to read the same in both places.
+	 */
 	@Override
 	public String getText(Object element) {
 		TreeNodeWrapper treeNodeWrapper = (TreeNodeWrapper) element;
 		IObject object = treeNodeWrapper.getObject();
-		Optional<String> textValue = _prefService.getValue(IBasicPreferenceService.Key.MODEL_VIEW_TEXT.getKey(),
-				String.class);
-		if (!(object instanceof IInstanz) || textValue.isEmpty()) {
+		if (!(object instanceof IInstanz instanz)) {
 			return treeNodeWrapper.toString();
 		}
-
-		String nameKey = ((IInstanz) object).getSingleValues(SingleValueType.SINGLE_STRING).inverse()
-				.get(textValue.get());
-		Optional<SingleStringValue> nameValue = _singleServise.resolveKey(SingleValueType.SINGLE_STRING.getPath(),
-				nameKey, SingleStringValue.class);
-		return nameValue.isEmpty() ? treeNodeWrapper.toString() : nameValue.get().getValue();
+		return _choices.labelOf(instanz);
 	}
 
 }

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/provider/TreeLabelProvider.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/provider/TreeLabelProvider.java
@@ -55,7 +55,7 @@ public class TreeLabelProvider implements ILabelProvider {
 
 	/**
 	 * Values read as themselves; an instanz reads by the rule in
-	 * {@link InstanzChoices#labelOf(IInstanz)}, which the combo box of a relation is
+	 * {@link InstanzChoices#labelOf(IInstanz)}, which the chooser of a relation is
 	 * filled from as well - the same instanz has to read the same in both places.
 	 */
 	@Override

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/util/MessagesUtil.java
@@ -25,6 +25,8 @@ public class MessagesUtil {
 			return messages.constant_type_boolean;
 		case SINGLE_FLOAT:
 			return messages.constant_type_float;
+		case SINGLE_INSTANZ:
+			return messages.constant_type_instanz;
 		default:
 			return type.name();
 		}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/widget/InstanzChooser.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/widget/InstanzChooser.java
@@ -1,0 +1,177 @@
+package de.tonsias.basis.ui.widget;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.jface.widgets.TextFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Text;
+
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
+
+/**
+ * Picks one instanz out of the model: a filter field over the tree the model
+ * is.
+ * <p>
+ * It used to be a {@code Combo} holding every instanz, flattened. That is
+ * unusable as soon as a model grows - no search, and none of the structure the
+ * user navigates by, see
+ * <a href="https://github.com/Tobias-Bonsack/Tonsias/issues/76">#76</a>. The
+ * source is still {@code InstanzChoices}, which now hands the tree over instead
+ * of flattening it.
+ * </p>
+ * <p>
+ * A widget rather than a dialog, because the three places that choose an
+ * instanz want it differently: the value dialog of a relation shows it inline,
+ * the Instanz View and the create dialog open {@link InstanzSelectionDialog}
+ * around it.
+ * </p>
+ */
+public class InstanzChooser extends Composite {
+
+	private final TreeViewer _viewer;
+
+	private final LabelFilter _filter = new LabelFilter();
+
+	private final Text _filterText;
+
+	/**
+	 * @param parent    to build into
+	 * @param root      the model as {@code InstanzChoices.tree()} hands it over
+	 * @param hintLabel what the filter field says while it is empty
+	 */
+	public InstanzChooser(Composite parent, Choice root, String hintLabel) {
+		super(parent, SWT.NONE);
+		GridLayoutFactory.fillDefaults().applyTo(this);
+
+		_filterText = TextFactory.newText(SWT.SEARCH | SWT.ICON_CANCEL)//
+				.message(hintLabel)//
+				.create(this);
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(_filterText);
+
+		_viewer = new TreeViewer(this, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+		GridDataFactory.fillDefaults().grab(true, true).applyTo(_viewer.getTree());
+		_viewer.setContentProvider(new ChoiceContentProvider());
+		_viewer.setLabelProvider(LabelProvider.createTextProvider(element -> ((Choice) element)._label()));
+		_viewer.addFilter(_filter);
+		_viewer.setInput(List.of(root));
+		_viewer.expandAll();
+
+		_filterText.addModifyListener(event -> refilter());
+	}
+
+	/**
+	 * Every keystroke narrows the tree, and everything left is opened - a match
+	 * hidden inside a collapsed branch would be no answer to a filter.
+	 */
+	private void refilter() {
+		_filter.setNeedle(_filterText.getText());
+		_viewer.refresh();
+		_viewer.expandAll();
+	}
+
+	/** @return the key of the chosen instanz, empty while nothing is chosen */
+	public String getSelectedKey() {
+		return selected() == null ? "" : selected()._key();
+	}
+
+	/** @return the label of the chosen instanz, empty while nothing is chosen */
+	public String getSelectedLabel() {
+		return selected() == null ? "" : selected()._label();
+	}
+
+	/**
+	 * Preselects the instanz a stored relation points at, so the user is not asked
+	 * to choose again to keep what is already there. A key the tree does not hold
+	 * leaves the selection empty - which is what a relation pointing nowhere is.
+	 */
+	public void setSelectedKey(String key) {
+		root().find(key).ifPresent(choice -> _viewer.setSelection(new StructuredSelection(choice), true));
+	}
+
+	/**
+	 * @param listener run whenever the chosen instanz changes - the OK button of
+	 *                 whoever holds this widget hangs on it
+	 */
+	public void onSelectionChanged(Runnable listener) {
+		_viewer.addSelectionChangedListener(event -> listener.run());
+	}
+
+	/** for the tests and for {@link #setSelectedKey}, which searches it */
+	public Choice root() {
+		return ((List<?>) _viewer.getInput()).stream().map(Choice.class::cast).findFirst().orElseThrow();
+	}
+
+	public TreeViewer getViewer() {
+		return _viewer;
+	}
+
+	public Text getFilterText() {
+		return _filterText;
+	}
+
+	private Choice selected() {
+		Object first = _viewer.getStructuredSelection().getFirstElement();
+		return first instanceof Choice choice ? choice : null;
+	}
+
+	private static class ChoiceContentProvider implements ITreeContentProvider {
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return ((List<?>) inputElement).toArray();
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			return ((Choice) parentElement)._children().toArray();
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			// the tree is walked downwards only; JFace uses this for reveal, and
+			// setSelection(.., true) works off the path it builds itself
+			return null;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			return !((Choice) element)._children().isEmpty();
+		}
+	}
+
+	/**
+	 * Keeps what the filter names, and every instanz on the way down to it: hiding
+	 * a parent would hide the match below it, and the tree would answer the filter
+	 * with nothing.
+	 */
+	private static class LabelFilter extends ViewerFilter {
+
+		private String _needle = "";
+
+		void setNeedle(String needle) {
+			_needle = needle.toLowerCase(Locale.ROOT);
+		}
+
+		@Override
+		public boolean select(Viewer viewer, Object parentElement, Object element) {
+			return matches((Choice) element);
+		}
+
+		private boolean matches(Choice choice) {
+			if (_needle.isEmpty() || choice._label().toLowerCase(Locale.ROOT).contains(_needle)) {
+				return true;
+			}
+			return choice._children().stream().anyMatch(this::matches);
+		}
+	}
+}

--- a/de.tonsias.basis.ui/src/de/tonsias/basis/ui/widget/InstanzSelectionDialog.java
+++ b/de.tonsias.basis.ui/src/de/tonsias/basis/ui/widget/InstanzSelectionDialog.java
@@ -1,0 +1,113 @@
+package de.tonsias.basis.ui.widget;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+
+import de.tonsias.basis.logic.part.InstanzChoices.Choice;
+import de.tonsias.basis.ui.i18n.Messages;
+
+/**
+ * An {@link InstanzChooser} on its own, for the two places that cannot show the
+ * tree where they stand: the Instanz View, which has one line per attribute,
+ * and the value column of the create dialog, which is a table cell.
+ * <p>
+ * What it hands back is the key of the chosen instanz - the label is the tree's
+ * business and is never stored.
+ * </p>
+ */
+public class InstanzSelectionDialog extends Dialog {
+
+	private final Choice _root;
+
+	private final Messages _messages;
+
+	private final String _preselectedKey;
+
+	private InstanzChooser _chooser;
+
+	/** read off the chooser before it is disposed, which closing the dialog does */
+	private String _selectedKey = "";
+
+	private String _selectedLabel = "";
+
+	/**
+	 * @param root           the model as {@code InstanzChoices.tree()} hands it over
+	 * @param preselectedKey where the relation points today, empty for none
+	 */
+	public InstanzSelectionDialog(Shell parentShell, Choice root, Messages messages, String preselectedKey) {
+		super(parentShell);
+		_root = root;
+		_messages = messages;
+		_preselectedKey = preselectedKey == null ? "" : preselectedKey;
+	}
+
+	@Override
+	protected void configureShell(Shell newShell) {
+		super.configureShell(newShell);
+		newShell.setText(_messages.dialog_selectInstanz_title);
+	}
+
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
+
+	@Override
+	protected Point getInitialSize() {
+		return new Point(400, 500);
+	}
+
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Composite composite = (Composite) super.createDialogArea(parent);
+
+		_chooser = new InstanzChooser(composite, _root, _messages.constant_filter);
+		GridDataFactory.fillDefaults().grab(true, true).applyTo(_chooser);
+		_chooser.setSelectedKey(_preselectedKey);
+		_chooser.onSelectionChanged(this::refreshOkButton);
+
+		return composite;
+	}
+
+	@Override
+	protected Control createButtonBar(Composite parent) {
+		Control buttonBar = super.createButtonBar(parent);
+		getButton(IDialogConstants.CANCEL_ID).setText(_messages.constant_cancel);
+
+		// the dialog area is built first, so there is a selection to judge by now -
+		// opening on a relation that already points somewhere may offer OK straight away
+		refreshOkButton();
+
+		return buttonBar;
+	}
+
+	private void refreshOkButton() {
+		getButton(IDialogConstants.OK_ID).setEnabled(!_chooser.getSelectedKey().isEmpty());
+	}
+
+	@Override
+	protected void okPressed() {
+		_selectedKey = _chooser.getSelectedKey();
+		_selectedLabel = _chooser.getSelectedLabel();
+		super.okPressed();
+	}
+
+	/** @return the key of the chosen instanz, empty unless OK was pressed */
+	public String getSelectedKey() {
+		return _selectedKey;
+	}
+
+	/** @return how that instanz read in the tree, for whoever has to show it */
+	public String getSelectedLabel() {
+		return _selectedLabel;
+	}
+
+	public InstanzChooser getChooser() {
+		return _chooser;
+	}
+}


### PR DESCRIPTION
Fuehrt `SingleValueType.SINGLE_INSTANZ` ein - das erste Attribut, das keine Zahl und kein Text ist, sondern eine **Relation**: eine Instanz zeigt damit auf eine andere.

Schliesst #74, #75, #76, #78 und #79 - closes #74, closes #75, closes #76, closes #78,
closes #79 (die englischen Schluesselwoerter, weil GitHub nur die verlinkt).

## Die tragende Entscheidung

`SingleInstanzValue extends ASingleValue<String>`, und `getValue()` liefert **den Key** der Ziel-Instanz, nicht die aufgeloeste Instanz.

Der Gedanke, `getValue()` selbst aufloesen zu lassen, scheitert an zwei Stellen des Bestands:

- `de.tonsias.basis.model` hat bewusst keine OSGi-Abhaengigkeit. `IInstanzService` liegt in `de.tonsias.basis.osgi.intf`, und `osgi` haengt von `model` ab - die Gegenrichtung waere ein Zyklus.
- Es gibt im Repo keinen polymorphen Gson-Adapter; `SaveServiceImpl` serialisiert mit `i.getClass()`. Ein `ASingleValue<IInstanz>` wuerde die komplette Ziel-Instanz in die Datei des Wertes schreiben, und Gson umgeht beim Laden die Konstruktoren, sodass ein transienter Resolver danach `null` waere.

Aufgeloest wird deshalb im Service: `IInstanzService.resolveInstanzValue(SingleInstanzValue)`. Sie sitzt dort und nicht auf `ISingleValueService`, weil der Instanz-Service Keys ohnehin aufloest - der andere haette erst eine neue `@Reference` gebraucht.

Der Gewinn daraus: **Persistenz und Delta-Faltung des Wertes bleiben unveraendert.** Die vier `SingleValue`-Events tragen den Typ als Feld, und die Datei landet als gewoehnliches JSON unter `single_value/instanz/<key>.json`.

## Die Relation wird an beiden Enden gehalten (#74)

Die erste Fassung fuehrte die Relation einseitig: der Wert kannte sein Ziel, das Ziel wusste von nichts. Eine geloeschte Instanz liess damit jeden Verweis auf einen Key stehen, der sich nicht mehr aufloest, und beim Speichern fiel es nicht auf.

`IInstanz` fuehrt jetzt die Keys der Werte mit, die **auf sie** zeigen - neben den Wert-Maps und aus demselben Grund, aus dem das Kind beim Elternteil steht. `ChangePropagationListener` haelt beide Enden in Schritt: er legt den Eintrag beim `new`-Event an, verschiebt ihn beim `valueChange` und nimmt ihn beim `delete` wieder heraus. Jeder dieser Schritte geht durch `IInstanzService`, das `false` liefert und nichts feuert, wenn die Menge schon sagt, was ihr gerade gesagt wird - so endet die Kette.

Beim Loeschen einer Instanz wird jeder Verweis auf sie **geleert, nicht geloescht**. Der Wert ist ein Attribut von jemand anderem, unter einem Namen, den dieser jemand vergeben hat; ein weggefallenes Ziel ist kein Grund, es ihm wegzunehmen. Damit es einen Weg zurueck nach "zeigt nirgendwohin" gibt, nimmt `tryToSetValue` den leeren String - den Zustand, in dem ein frischer Verweis ohnehin startet. `accepts` weist ihn weiter zurueck, denn das ist die Frage, die der Dialog stellt: nichts ausgewaehlt darf kein Wert werden.

Das ist die eine Stelle, an der ein **neues Topic** noetig war - die Menge liegt auf der Instanz, also muss die Instanz geschrieben werden: `instanz/delta/referenceChange`, sein Payload-Record, sein Eintrag in `KNOWN_DELTA` und in der Delta-Faltung.

## Ausgewaehlt wird in einem Baum mit Filter (#76)

Die Combo hielt jede Instanz des Modells, flachgeklopft. Sie kam ohne neue Abhaengigkeit aus, war aber die Obergrenze dafuer, wie gross ein Modell werden darf, bevor Relationen unbenutzbar sind: keine Suche, und nichts von der Struktur, an der man sich orientiert.

- `InstanzChoices` liefert deshalb den Baum statt ihn flachzuklopfen. `Choice` traegt seine Kinder, mit `flatten()` und `find(key)` fuer die Aufrufer, die einen Eintrag oder eine Reihenfolge brauchen.
- `InstanzChooser` zeichnet diesen Baum mit einem Filterfeld darueber und laesst den Ast oberhalb eines Treffers stehen - das Elternteil zu verstecken wuerde den Treffer mit verstecken.
- Drei Stellen waehlen eine Instanz aus und koennen nicht alle einen Baum an Ort und Stelle zeigen, deshalb ist das Widget das eine und `InstanzSelectionDialog` darum herum das andere. Der Wert-Dialog der Relation zeigt den Baum **inline** - er ist selbst schon ein Dialog, und einer, der fuer ein einziges Feld einen zweiten oeffnet, verlangt zwei OKs fuer eine Entscheidung. Der Instanz View hat eine Zeile pro Attribut und zeigt deshalb einen Button, der sagt, wohin die Relation zeigt, und den Dialog oeffnet.

## Der Erstellen-Dialog fuellt eine Relation ebenso (#75)

Die Wertspalte war eine Spalte fuer alle Typen: ein Text-Zelleneditor. Fuer eine Relation hiess das, den rohen Key abzutippen - was `SingleInstanzValue.accepts` sogar annimmt, weil die Key-Form stimmt.

Der Editor haengt jetzt an der Zeile: eine Relation bekommt einen `DialogCellEditor`, der denselben `InstanzSelectionDialog` oeffnet, und die Spalte zeigt das Label des Ziels statt seines Keys. Ein Typwechsel wirft einen Wert weg, den der neue Typ nicht nehmen wuerde - diese Regel liegt im Logic-Bundle, wo sie ohne SWT testbar ist, zusammen mit der Label-Aufloesung.

## Was sonst dazukommt

- **Modell** - `SingleInstanzValue` mit `accepts(String)` in der Rolle, die `SingleIntegerValue.accepts` seit #68 hat: der Dialog fragt den Typ, statt die Regel zu wiederholen. Neue Enum-Konstante ans Ende, wie der Kommentar dort es verlangt. Kein Feld-Initializer fuer die neue Menge - Gson ueberspringt die, und eine vor diesem Stand geschriebene Instanz nennt sie gar nicht.
- **Services** - ein `case` in der Factory von `SingleValueServiceImpl`, sonst nichts: `resolveKey`, `changeValue`, `saveAll`, `addToParent` und die Ordnersuche in `deleteFile` laufen ueber `values()` und nehmen den Typ von selbst mit.
- **Logic** - `InstanzChoices` laeuft den Baum ab und beschriftet jede Instanz so, wie die Model View es tut; `TreeLabelProvider` fragt dieselbe Methode, statt die Regel ein zweites Mal zu fuehren.
- **UI** - fuenfter Menueeintrag in `ModelView`, `constant_type_instanz`, `constant_filter`, `constant_noInstanz` und `dialog_selectInstanz_title` in beiden Sprachdateien.

## Tests

588 gruen. Neu: `SingleInstanzValueTest`, `InstanzChoicesSystemTest`, `InstanzSelectionDialogSystemTest`, dazu Faelle in `AInstanzTest`, `InstanzServiceSystemTest` (beide Reference-Methoden samt ihrer Schweige-Garantie), `ChangePropagationSystemTest` (die ganze Kette: anlegen, umhaengen, loeschen des Wertes, loeschen des Ziels - auch ueber einen Teilbaum, mit zwei Verweisen auf dasselbe Ziel und mit einem Verweis auf sich selbst), `SingleValueServiceSystemTest` (eigener Ordner, Round-Trip, `resolveInstanzValue`, die Menge auf der Platte), `CreateInstanzDialogLogicSystemTest` und `ValueDialogSystemTest` (Baum statt Combo, und was der Filter stehen laesst). Fuer #78 und #79 je ein Fall, der den Wert vorher aus dem Cache nimmt: eine Aenderung und eine Loeschmarkierung allein ueber die Datei, ein Treffer im richtigen Ordner nach einem Fehlgriff im falschen, und das Leeren eines Verweises, den nur die Platte kennt.

`ValueDialogSystemTest` liess sich nicht einfach erweitern: der Helfer `texts()` behauptete drei `Text`-Felder, die ein Dialog mit Baum nicht in derselben Rolle hat. Die Zusicherung steht jetzt in `valueText()` - dem Helfer, der ohne sie auf dem falschen Widget landen koennte.

## Zwei Dinge, die hier mit drin sind

- `com.google.guava` kommt in das Manifest von `de.tonsias.basis.logic`. Das Modell gibt `BiMap` heraus, und die Label-Regel liest deren Namensseite; ohne die Abhaengigkeit ist `inverse()` eine Access-Restriction. `de.tonsias.basis.ui` fuehrt sie aus demselben Grund.
- `onSingleValueSelect` in `InstanzView` nimmt den weiterzureichenden Wert jetzt als Parameter, statt ihn vom `Button` zu lesen - sonst haetten Checkbox und Auswahl-Button zwei fast gleiche Methoden gebraucht.

## Unterwegs gefunden und gleich mit erledigt (#78, #79)

Beim Leeren der Verweise fiel auf, dass `ISingleValueService` an zwei Stellen den Cache fuer die ganze Wahrheit haelt:

- **#78** - `changeValue` und `markSingleValueAsDelete` lasen `_cache.get(key)` und dereferenzierten das Ergebnis. Jeder Wert, den diese Sitzung noch nicht angefasst hat - nach einem Neustart also jeder -, war eine `NullPointerException` aus dem Service heraus. Alle anderen Methoden loesen auf und fallen auf die Datei zurueck; diese beiden waren die Ausnahme. `resolveKey` allein reicht nicht, weil ein Key nicht sagt, welchen Typ er hat - das sagt nur der Ordner, in dem seine Datei liegt. `resolveAnyKey` probiert deshalb einen Typordner nach dem anderen, genau wie `deleteFile` es aus demselben Grund schon tut.
- **#79** - genau diese Ordnersuche machte den zweiten Fehler erreichbar: `resolveKey` legte ein fehlgeschlagenes Laden als `null` im Cache ab. Der Key galt damit als beantwortet, und der naechste Blick - in den richtigen Ordner - bekam dasselbe Nichts zurueck. Gecacht wird jetzt nur noch, was auch gefunden wurde.

Damit braucht `ChangePropagationListener.emptyReferencesPointingAt` keine Umgehung mehr: die Key-Menge auf der Ziel-Instanz reicht fuer sich, ueber einen Neustart hinweg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
