### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to Tonsias are documented here. The format follows
 
 ## [Unreleased]
 
-Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
+Nothing yet. The reactor is at `0.2.0`.
+
+## [0.2.0] - 2026-08-09
+
+Two more attribute types — a decimal number and, for the first time, a **relation** that
+points at another instanz — and a test suite that no longer substitutes anything: every
+one of the 588 tests drives the services the running application registers.
 
 ### Added
 
@@ -128,6 +134,9 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 - `ISingleValueService.resolveKey(..)` no longer remembers a failed load. It put the
   `null` into the cache, so the key counted as asked and answered from then on and the
   next look — in the right folder — got the same nothing back ([#79]).
+- The `README.md` example for running a single test names `KeyServiceSystemTest`, which
+  exists, instead of `KeyServiceImplTest`, which has not since the tests were rewritten
+  ([#80]).
 
 [#52]: https://github.com/Tobias-Bonsack/Tonsias/issues/52
 [#53]: https://github.com/Tobias-Bonsack/Tonsias/issues/53
@@ -145,6 +154,27 @@ Development towards 0.2.0. The reactor is at `0.2.0-SNAPSHOT`.
 [#76]: https://github.com/Tobias-Bonsack/Tonsias/issues/76
 [#78]: https://github.com/Tobias-Bonsack/Tonsias/issues/78
 [#79]: https://github.com/Tobias-Bonsack/Tonsias/issues/79
+[#80]: https://github.com/Tobias-Bonsack/Tonsias/issues/80
+
+### Distribution
+
+- `tonsias-win32.win32.x86_64.zip` — the runnable application for Windows x86_64, with
+  the `jre` directory `jlink` builds next to the launcher. No Java on the `PATH` is
+  needed any more; the product declares no `-vm`, so that directory has to travel with
+  it.
+- `de.tonsias.basis.product-0.2.0.zip` — the p2 repository, for installing or updating
+  from Eclipse.
+
+### Known limitations
+
+- Only a Windows x86_64 product is built. Other platforms need additional
+  `<environment>` entries in `target-platform-configuration`.
+- Instanzen can be created but not deleted from the user interface.
+- A single value's `REMOVE` direction is still open in two places of
+  `ChangePropagationListener`: dropping a value key from an instanz, and dropping an
+  instanz from a value's owner list, are answered by the services alone.
+- The bundles declare inconsistent Java compliance levels (19 / 22 / 24), which is why
+  the build pins its resolution execution environment to `JavaSE-24`.
 
 ## [0.1.0] - 2026-08-07
 
@@ -234,5 +264,6 @@ is a summary of what the release contains rather than of what changed.
 - The bundles declare inconsistent Java compliance levels (19 / 22 / 24), which is why
   the build pins its resolution execution environment to `JavaSE-24`.
 
-[Unreleased]: https://github.com/Tobias-Bonsack/Tonsias/compare/v0.1.0...main
+[Unreleased]: https://github.com/Tobias-Bonsack/Tonsias/compare/v0.2.0...main
+[0.2.0]: https://github.com/Tobias-Bonsack/Tonsias/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Every change follows this sequence, and **never commit directly to `main`**:
 
 ## Releasing
 
-Latest release **0.1.0**; the reactor is on **0.2.0-SNAPSHOT**. `CHANGELOG.md` is the per-release record, `README.md` the user-facing overview. Versions live in 37 files — **never edit them by hand**:
+Latest release **0.2.0**; the reactor is on **0.3.0-SNAPSHOT**. `CHANGELOG.md` is the per-release record, `README.md` the user-facing overview. Versions live in 37 files — **never edit them by hand**:
 
 ```powershell
 $env:JAVA_HOME = '<jdk24>'

--- a/README.md
+++ b/README.md
@@ -3,23 +3,24 @@
 [![Build](https://github.com/Tobias-Bonsack/Tonsias/actions/workflows/build.yml/badge.svg)](https://github.com/Tobias-Bonsack/Tonsias/actions/workflows/build.yml)
 
 Tonsias is an Eclipse RCP / e4 desktop application for modelling data as a tree.
-Every node is an _Instanz_; every Instanz carries named _single values_ (string or
-integer) as its attributes. Nothing is stored in one big document — each Instanz and
-each value is its own small JSON file, and every change travels through an event bus
-before it is written, so the whole model stays observable and every edit is visible
-and revocable until it is saved.
+Every node is an _Instanz_; every Instanz carries named _single values_ (text, whole
+number, decimal number, yes-or-no, or a reference to another Instanz) as its
+attributes. Nothing is stored in one big document — each Instanz and each value is its
+own small JSON file, and every change travels through an event bus before it is
+written, so the whole model stays observable and every edit is visible and revocable
+until it is saved.
 
-> **Version 0.1.0 is the first release.** It is an early, functional snapshot: the
-> model, the persistence, the event chain and three views work end to end, but the
-> feature set is deliberately small and only a Windows x86_64 build is produced.
+> **Version 0.2.0 is the current release.** It is still an early snapshot: the model,
+> the persistence, the event chain and three views work end to end, but the feature set
+> is deliberately small and only a Windows x86_64 build is produced.
 
-## Features in 0.1.0
+## Features in 0.2.0
 
 ### Views
 
 - **Model View** — the whole model as a tree of Instanzen and their values.
-  Its context menu (also reachable with `Ctrl+N`) creates a child Instanz, adds a
-  string or an integer single value through a dialog, or deletes a value. The tree
+  Its context menu (also reachable with `Ctrl+N`) creates a child Instanz, adds a single
+  value of any of the five types through a dialog, or deletes a value. The tree
   refreshes itself from model events instead of polling, and which value is used as a
   node's label is a preference.
 - **Property View** — everything about the selected Instanz: own key, parent key,
@@ -29,6 +30,17 @@ and revocable until it is saved.
   and switching to another Instanz while dirty asks first whether to keep the changes.
 - **Delta View** — every change since the last save, as a tree grouped per operation.
   Its toolbar refreshes the tree and saves everything in one go.
+
+### Attribute types
+
+- **Text**, **whole number**, **decimal number** and **yes-or-no**. Each type answers for
+  what it takes: the dialog asks the type itself, greys out its OK button for input the
+  model would discard, and nothing is silently stored as `0` or left cleared.
+- **Instanz reference** — a relation, pointing at another Instanz. The target is chosen
+  from a tree of the model with a filter field, never typed as a raw key, and it can be
+  followed back to the Instanz it names. The relation is held at both ends: deleting the
+  target puts every reference to it back to pointing nowhere instead of leaving a key
+  that resolves to nothing, and the attribute itself stays with its owner.
 
 ### Editing and saving
 
@@ -44,7 +56,8 @@ and revocable until it is saved.
 ### Persistence
 
 - One JSON file per object, written with Gson under the Eclipse instance location:
-  `instanz/<key>.json`, `single_value/string/<key>.json`, `single_value/integer/<key>.json`.
+  `instanz/<key>.json` and `single_value/<type>/<key>.json`, one folder per attribute
+  type.
 - Objects are referenced by string key, never by object reference; the services cache
   what they have loaded and only touch the disk on a miss or a save.
 - Keys come from a base-36 counter over a lower-case alphabet, persisted in the Eclipse
@@ -62,27 +75,29 @@ and revocable until it is saved.
 
 - A headless **Tycho** build mirrors the IDE: `.\build.ps1` compiles every bundle, runs
   every test bundle inside a real Equinox, and materialises the runnable product.
-- The test bundles cover the model, the JSON persistence, the services, the view logic
-  and the complete event chain. All of them run inside OSGi.
+- **Every one of the 588 tests is a system test**: it drives the services the running
+  application registers, on the real event bus, against the real workspace files, and —
+  for the views — on a real SWT `Display`. Nothing is substituted; there is no mocking
+  framework in the target platform.
 - GitHub Actions builds every push and pull request on Windows and posts the per-bundle
   test results as a single, edited-in-place pull request comment.
 
 ## Download and run
 
 1. Take `tonsias-win32.win32.x86_64.zip` from the
-   [0.1.0 release](https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.1.0).
+   [0.2.0 release](https://github.com/Tobias-Bonsack/Tonsias/releases/tag/v0.2.0).
 2. Unzip it anywhere and start `Tonsias.exe`.
 
-From 0.2.0 on the zip is self-contained: it carries its own Java runtime in `jre/`
-next to the launcher, so **nothing has to be installed** and the launcher finds a VM
-without a `-vm` argument. The 0.1.0 zip does not — it needs Java 24 or newer on the
-`PATH`, or an explicit `Tonsias.exe -vm <jdk>\bin\javaw.exe`, and starts silently into
-nothing without either.
+The zip is self-contained: it carries its own Java runtime in `jre/` next to the
+launcher, so **nothing has to be installed** and the launcher finds a VM without a
+`-vm` argument. Keep that directory next to the executable — the product declares no
+`-vm`, so without it the launcher starts silently into nothing. (The older 0.1.0 zip
+has no `jre/` and needs Java 24 or newer on the `PATH`.)
 
 The model is written to the application's instance location — the path is shown in
 `Window > Preferences` and can be pointed elsewhere with `-data <directory>`.
 
-`de.tonsias.basis.product-0.1.0.zip` in the same release is the p2 repository, for
+`de.tonsias.basis.product-0.2.0.zip` in the same release is the p2 repository, for
 installing or updating Tonsias from within Eclipse instead.
 
 ## Build from source
@@ -90,7 +105,7 @@ installing or updating Tonsias from within Eclipse instead.
 ```powershell
 .\build.ps1                                # compile, test, materialize the product
 .\build.ps1 -SkipTests                     # product only
-.\build.ps1 -- -Dtest=KeyServiceImplTest   # everything after -- goes to Maven verbatim
+.\build.ps1 -- -Dtest=KeyServiceSystemTest # everything after -- goes to Maven verbatim
 ```
 
 `build.ps1` exists because `JAVA_HOME` is usually not set on a development machine: it
@@ -165,10 +180,9 @@ package is exported to the test bundle alone.
   injection mechanisms that coexist, persistence layout, conventions, and the rules a
   change has to follow.
 
-## Known limitations in 0.1.0
+## Known limitations in 0.2.0
 
 - Only a Windows x86_64 product is built.
-- Single values are limited to string and integer.
 - Instanzen can be created but not deleted from the user interface; values can.
 - The Java compliance levels of the bundles are inconsistent (19 / 22 / 24), which is
   why the Tycho build has to pin its resolution execution environment.

--- a/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.data.access.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: de.tonsias.basis.data.access;bundle-version="0.2.0",
  de.tonsias.basis.model;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",

--- a/de.tonsias.basis.data.access.test/pom.xml
+++ b/de.tonsias.basis.data.access.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Access
 Bundle-SymbolicName: de.tonsias.basis.data.access
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.data.access.osgi.impl;x-friends:="de.tonsias.basis.data.access.test",
  de.tonsias.basis.data.access.osgi.intf
 Require-Bundle: org.osgi.service.component.annotations;bundle-version="1.5.1";resolution:=optional,

--- a/de.tonsias.basis.data.access/pom.xml
+++ b/de.tonsias.basis.data.access/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.feature/feature.xml
+++ b/de.tonsias.basis.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.basis.feature"
       label="Tonsias"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.basis.feature/pom.xml
+++ b/de.tonsias.basis.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.feature</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.basis.icon/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.icon/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Icon
 Bundle-SymbolicName: de.tonsias.basis.icon
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.icon
 Automatic-Module-Name: de.tonsias.basis.icon
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.icon/pom.xml
+++ b/de.tonsias.basis.icon/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.icon</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.logic.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: de.tonsias.basis.logic.test
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.basis.logic.test/pom.xml
+++ b/de.tonsias.basis.logic.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.basis.logic
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: de.tonsias.basis.logic
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.basis.logic/pom.xml
+++ b/de.tonsias.basis.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.model.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: de.tonsias.basis.model;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",

--- a/de.tonsias.basis.model.test/pom.xml
+++ b/de.tonsias.basis.model.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model
 Bundle-SymbolicName: de.tonsias.basis.model
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.model.enums,
  de.tonsias.basis.model.impl,
  de.tonsias.basis.model.impl.value,

--- a/de.tonsias.basis.model/pom.xml
+++ b/de.tonsias.basis.model/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.osgi.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.osgi.test;x-friends:="de.tonsias.basis.logic.test,de.tonsias.basis.ui.test,de.tonsias.delta.view.ui.test"
 Require-Bundle: de.tonsias.basis.osgi;bundle-version="0.2.0",
  org.osgi.service.event;bundle-version="1.4.1",

--- a/de.tonsias.basis.osgi.test/pom.xml
+++ b/de.tonsias.basis.osgi.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Osgi
 Bundle-SymbolicName: de.tonsias.basis.osgi
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.osgi.impl;x-friends:="de.tonsias.basis.osgi.test",
  de.tonsias.basis.osgi.intf,
  de.tonsias.basis.osgi.intf.non.service,

--- a/de.tonsias.basis.osgi/pom.xml
+++ b/de.tonsias.basis.osgi/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.product/pom.xml
+++ b/de.tonsias.basis.product/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.product</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>

--- a/de.tonsias.basis.product/tonsias.product
+++ b/de.tonsias.basis.product/tonsias.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.2.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.2.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>

--- a/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: i18n
 Bundle-SymbolicName: de.tonsias.basis.ui.i18n
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.ui.i18n;x-friends:="de.tonsias.basis.u
  i,de.tonsias.basis.ui.test"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0"

--- a/de.tonsias.basis.ui.i18n/pom.xml
+++ b/de.tonsias.basis.ui.i18n/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui.i18n</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.ui.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: de.tonsias.basis.ui;bundle-version="0.2.0",
  de.tonsias.basis.ui.i18n;bundle-version="0.2.0",
  de.tonsias.basis.logic;bundle-version="0.2.0",

--- a/de.tonsias.basis.ui.test/pom.xml
+++ b/de.tonsias.basis.ui.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: de.tonsias.basis.ui;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.basis.ui.dialog;x-friends:="de.tonsias.basis
  .ui.test",
  de.tonsias.basis.ui.util;x-friends:="de.tonsias.basis.ui.test",

--- a/de.tonsias.basis.ui/pom.xml
+++ b/de.tonsias.basis.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.feature/feature.xml
+++ b/de.tonsias.delta.view.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.delta.view.feature"
       label="Tonsias Delta View"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.delta.view.feature/pom.xml
+++ b/de.tonsias.delta.view.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.feature</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.delta.view.logic
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: de.tonsias.delta.view.logic
 Bundle-RequiredExecutionEnvironment: JavaSE-22

--- a/de.tonsias.delta.view.logic/pom.xml
+++ b/de.tonsias.delta.view.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.logic</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.delta.view.ui.test
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: de.tonsias.delta.view.ui;bundle-version="0.2.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",

--- a/de.tonsias.delta.view.ui.test/pom.xml
+++ b/de.tonsias.delta.view.ui.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui.test</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DeltaViewUI
 Bundle-SymbolicName: de.tonsias.delta.view.ui
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: de.tonsias.delta.view.ui;x-friends:="de.tonsias.delta.vi
  ew.ui.test",de.tonsias.delta.view.ui.tree;x-friends:="de.tonsias.delta.
  view.ui.test"

--- a/de.tonsias.delta.view.ui/pom.xml
+++ b/de.tonsias.delta.view.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>de.tonsias</groupId>
 	<artifactId>de.tonsias.parent</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>pom</packaging>
 
 	<name>Tonsias</name>
@@ -69,7 +69,7 @@
 						<artifact>
 							<groupId>de.tonsias</groupId>
 							<artifactId>target-platform</artifactId>
-							<version>0.2.0-SNAPSHOT</version>
+							<version>0.2.0</version>
 						</artifact>
 					</target>
 					<!--

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>target-platform</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>eclipse-target-definition</packaging>
 </project>


### PR DESCRIPTION
Setzt den Reaktor auf **0.2.0** und schreibt die Release-Notizen. Kein Produktionscode aendert sich - was in dieses Release geht, liegt schon auf `main`.

Closes #80.

## Versionen

`tycho-versions-plugin:set-version` hat alle 38 Dateien angefasst. Das `version`-Attribut in `tonsias.product` stand auf `0.2.0.qualifier` und damit auf dem alten Wert, wurde also nicht uebersprungen - es steht jetzt auf `0.2.0`, genau wie beim v0.1.0-Tag.

## CHANGELOG.md

Der `Unreleased`-Abschnitt wird zu `[0.2.0] - 2026-08-09`. Dazugekommen sind, wie schon bei 0.1.0:

- **Distribution** - was im Release haengt. Der Unterschied zu 0.1.0: die Produkt-Zip traegt ihr eigenes `jre/` neben dem Launcher, es muss nichts mehr installiert sein.
- **Known limitations** - ohne die zwei, die dieses Release beseitigt (Werte nur Text und Ganzzahl; kein `jre`), und dafuer mit der einen, die `ChangePropagationListener` weiterhin offen laesst: die `REMOVE`-Richtung an beiden `// TODO: add logic`.

## README.md

- Fuenf Attributtypen statt zwei, mit einem eigenen Abschnitt dazu: was jeder Typ annimmt, und wie ein Instanzverweis gefuellt wird - aus einem Baum mit Filter, nie als abgetippter Key - und dass die Relation an beiden Enden gehalten wird.
- Der Persistenz-Abschnitt nennt `single_value/<type>/<key>.json` statt zwei einzelne Ordner aufzuzaehlen, die inzwischen fuenf sind.
- Der Download-Abschnitt zeigt auf die 0.2.0-Artefakte und sagt, dass das `jre/`-Verzeichnis neben der Exe bleiben muss - ohne `-vm` im Produkt startet der Launcher sonst lautlos ins Nichts.
- Die Testzeile nennt 588 System-Tests und dass nichts substituiert wird.
- **#80** - das Beispiel zum Laufenlassen eines einzelnen Tests nannte `KeyServiceImplTest`. Die Klasse gibt es seit dem Umbau auf System-Tests nicht mehr, und Surefire wertet ein leeres Filterergebnis nicht als Fehler - der Lauf sieht also gruen aus und hat nichts getan. Hier mit erledigt, weil die Datei fuer dieses Release ohnehin ueberarbeitet wird.

## CLAUDE.md

Eine Zeile: letztes Release 0.2.0, Reaktor auf 0.3.0-SNAPSHOT. Der Bump selbst kommt direkt nach dem Tag in einem eigenen PR, so wie nach v0.1.0.

## Gebaut

`.\build.ps1` gruen, **588 Tests, 0 Fehler**. Beide Artefakte liegen mit den Namen vor, die CHANGELOG und README nennen: `tonsias-win32.win32.x86_64.zip` (76 MB, mit `jre/`) und `de.tonsias.basis.product-0.2.0.zip` (19 MB, p2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
