### PR TITLE
Reaktor auf 0.3.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Tonsias are documented here. The format follows
 
 ## [Unreleased]
 
-Nothing yet. The reactor is at `0.2.0`.
+Development towards 0.3.0. The reactor is at `0.3.0-SNAPSHOT`.
 
 ## [0.2.0] - 2026-08-09
 

--- a/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access.test/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.data.access.test
-Bundle-Version: 0.2.0
-Require-Bundle: de.tonsias.basis.data.access;bundle-version="0.2.0",
- de.tonsias.basis.model;bundle-version="0.2.0",
+Bundle-Version: 0.3.0.qualifier
+Require-Bundle: de.tonsias.basis.data.access;bundle-version="0.3.0",
+ de.tonsias.basis.model;bundle-version="0.3.0",
  org.hamcrest;bundle-version="2.2.0",
  org.eclipse.core.runtime;bundle-version="3.31.0",
  junit-jupiter-api;bundle-version="5.11.1",

--- a/de.tonsias.basis.data.access.test/pom.xml
+++ b/de.tonsias.basis.data.access.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.data.access/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Access
 Bundle-SymbolicName: de.tonsias.basis.data.access
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.data.access.osgi.impl;x-friends:="de.tonsias.basis.data.access.test",
  de.tonsias.basis.data.access.osgi.intf
 Require-Bundle: org.osgi.service.component.annotations;bundle-version="1.5.1";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.31.0",
  com.google.guava;bundle-version="33.1.0",
  com.google.gson;bundle-version="2.10.1",
- de.tonsias.basis.model;bundle-version="0.2.0"
+ de.tonsias.basis.model;bundle-version="0.3.0"
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.data.access
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.data.access/pom.xml
+++ b/de.tonsias.basis.data.access/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.data.access</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.feature/feature.xml
+++ b/de.tonsias.basis.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.basis.feature"
       label="Tonsias"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.basis.feature/pom.xml
+++ b/de.tonsias.basis.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.feature</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.basis.icon/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.icon/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Icon
 Bundle-SymbolicName: de.tonsias.basis.icon
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.icon
 Automatic-Module-Name: de.tonsias.basis.icon
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.icon/pom.xml
+++ b/de.tonsias.basis.icon/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.icon</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.logic.test
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: de.tonsias.basis.logic.test
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24
@@ -11,9 +11,9 @@ Require-Bundle: org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",
  junit-jupiter-params;bundle-version="5.11.1",
- de.tonsias.basis.logic;bundle-version="0.2.0",
+ de.tonsias.basis.logic;bundle-version="0.3.0",
  de.tonsias.basis.osgi,
- de.tonsias.basis.osgi.test;bundle-version="0.2.0",
+ de.tonsias.basis.osgi.test;bundle-version="0.3.0",
  de.tonsias.basis.model,
  org.eclipse.e4.core.services;bundle-version="2.5.200",
  com.google.guava;bundle-version="33.1.0",

--- a/de.tonsias.basis.logic.test/pom.xml
+++ b/de.tonsias.basis.logic.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.basis.logic
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: de.tonsias.basis.logic
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.basis.logic/pom.xml
+++ b/de.tonsias.basis.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.logic</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.model.test
-Bundle-Version: 0.2.0
-Require-Bundle: de.tonsias.basis.model;bundle-version="0.2.0",
+Bundle-Version: 0.3.0.qualifier
+Require-Bundle: de.tonsias.basis.model;bundle-version="0.3.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",

--- a/de.tonsias.basis.model.test/pom.xml
+++ b/de.tonsias.basis.model.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.model/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model
 Bundle-SymbolicName: de.tonsias.basis.model
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.model.enums,
  de.tonsias.basis.model.impl,
  de.tonsias.basis.model.impl.value,

--- a/de.tonsias.basis.model/pom.xml
+++ b/de.tonsias.basis.model/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.model</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi.test/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.osgi.test
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.osgi.test;x-friends:="de.tonsias.basis.logic.test,de.tonsias.basis.ui.test,de.tonsias.delta.view.ui.test"
-Require-Bundle: de.tonsias.basis.osgi;bundle-version="0.2.0",
+Require-Bundle: de.tonsias.basis.osgi;bundle-version="0.3.0",
  org.osgi.service.event;bundle-version="1.4.1",
  org.hamcrest;bundle-version="2.2.0",
  org.eclipse.core.runtime;bundle-version="3.31.0",

--- a/de.tonsias.basis.osgi.test/pom.xml
+++ b/de.tonsias.basis.osgi.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.osgi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Osgi
 Bundle-SymbolicName: de.tonsias.basis.osgi
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.osgi.impl;x-friends:="de.tonsias.basis.osgi.test",
  de.tonsias.basis.osgi.intf,
  de.tonsias.basis.osgi.intf.non.service,
@@ -17,7 +17,7 @@ Require-Bundle: org.osgi.service.component.annotations;bundle-version="1.5.1",
  jakarta.inject.jakarta.inject-api;bundle-version="2.0.1",
  jakarta.annotation-api;bundle-version="2.1.1",
  de.tonsias.basis.model;bundle-version="0.0.0",
- de.tonsias.basis.data.access;bundle-version="0.2.0",
+ de.tonsias.basis.data.access;bundle-version="0.3.0",
  com.google.guava
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.osgi

--- a/de.tonsias.basis.osgi/pom.xml
+++ b/de.tonsias.basis.osgi/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.osgi</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.product/pom.xml
+++ b/de.tonsias.basis.product/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.product</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>

--- a/de.tonsias.basis.product/tonsias.product
+++ b/de.tonsias.basis.product/tonsias.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.2.0" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Tonsias" uid="tonsias" id="de.tonsias.basis.ui.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.3.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>

--- a/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.i18n/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: i18n
 Bundle-SymbolicName: de.tonsias.basis.ui.i18n
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.ui.i18n;x-friends:="de.tonsias.basis.u
  i,de.tonsias.basis.ui.test"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0"

--- a/de.tonsias.basis.ui.i18n/pom.xml
+++ b/de.tonsias.basis.ui.i18n/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui.i18n</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui.test/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.basis.ui.test
-Bundle-Version: 0.2.0
-Require-Bundle: de.tonsias.basis.ui;bundle-version="0.2.0",
- de.tonsias.basis.ui.i18n;bundle-version="0.2.0",
- de.tonsias.basis.logic;bundle-version="0.2.0",
- de.tonsias.basis.model;bundle-version="0.2.0",
- de.tonsias.basis.osgi;bundle-version="0.2.0",
- de.tonsias.basis.osgi.test;bundle-version="0.2.0",
+Bundle-Version: 0.3.0.qualifier
+Require-Bundle: de.tonsias.basis.ui;bundle-version="0.3.0",
+ de.tonsias.basis.ui.i18n;bundle-version="0.3.0",
+ de.tonsias.basis.logic;bundle-version="0.3.0",
+ de.tonsias.basis.model;bundle-version="0.3.0",
+ de.tonsias.basis.osgi;bundle-version="0.3.0",
+ de.tonsias.basis.osgi.test;bundle-version="0.3.0",
  org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.jface;bundle-version="3.33.0",
  org.eclipse.swt;bundle-version="3.125.0",

--- a/de.tonsias.basis.ui.test/pom.xml
+++ b/de.tonsias.basis.ui.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.basis.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.basis.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: de.tonsias.basis.ui;singleton:=true
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.basis.ui.dialog;x-friends:="de.tonsias.basis
  .ui.test",
  de.tonsias.basis.ui.util;x-friends:="de.tonsias.basis.ui.test",
@@ -16,17 +16,17 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.e4.core.contexts;bundle-version="1.12.500",
  jakarta.inject.jakarta.inject-api;bundle-version="2.0.1",
  jakarta.annotation-api;bundle-version="2.1.1",
- de.tonsias.basis.osgi;bundle-version="0.2.0",
- de.tonsias.basis.model;bundle-version="0.2.0",
+ de.tonsias.basis.osgi;bundle-version="0.3.0",
+ de.tonsias.basis.model;bundle-version="0.3.0",
  com.google.guava,
  org.osgi.service.component;bundle-version="1.5.1",
  org.eclipse.e4.core.services,
  org.eclipse.e4.ui.model.workbench;bundle-version="2.4.200",
- de.tonsias.basis.logic;bundle-version="0.2.0",
+ de.tonsias.basis.logic;bundle-version="0.3.0",
  org.osgi.service.event;bundle-version="1.4.1",
  de.tonsias.basis.ui.i18n,
  org.eclipse.jface.notifications;bundle-version="0.7.400",
- de.tonsias.basis.icon;bundle-version="0.2.0"
+ de.tonsias.basis.icon;bundle-version="0.3.0"
 Bundle-Vendor: TONSIAS
 Automatic-Module-Name: de.tonsias.basis.ui
 Bundle-ActivationPolicy: lazy

--- a/de.tonsias.basis.ui/pom.xml
+++ b/de.tonsias.basis.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.basis.ui</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.feature/feature.xml
+++ b/de.tonsias.delta.view.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.tonsias.delta.view.feature"
       label="Tonsias Delta View"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="TONSIAS">
 
    <description url="https://github.com/Tobias-Bonsack/Tonsias">

--- a/de.tonsias.delta.view.feature/pom.xml
+++ b/de.tonsias.delta.view.feature/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.feature</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.logic/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logic
 Bundle-SymbolicName: de.tonsias.delta.view.logic
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: de.tonsias.delta.view.logic
 Bundle-RequiredExecutionEnvironment: JavaSE-22

--- a/de.tonsias.delta.view.logic/pom.xml
+++ b/de.tonsias.delta.view.logic/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.logic</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui.test/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: de.tonsias.delta.view.ui.test
-Bundle-Version: 0.2.0
-Require-Bundle: de.tonsias.delta.view.ui;bundle-version="0.2.0",
+Bundle-Version: 0.3.0.qualifier
+Require-Bundle: de.tonsias.delta.view.ui;bundle-version="0.3.0",
  org.hamcrest;bundle-version="2.2.0",
  junit-jupiter-api;bundle-version="5.11.1",
  junit-jupiter-engine;bundle-version="5.11.1",
  junit-jupiter-params;bundle-version="5.11.1",
  de.tonsias.basis.osgi,
- de.tonsias.basis.osgi.test;bundle-version="0.2.0",
- de.tonsias.basis.model;bundle-version="0.2.0",
+ de.tonsias.basis.osgi.test;bundle-version="0.3.0",
+ de.tonsias.basis.model;bundle-version="0.3.0",
  org.osgi.service.event;bundle-version="1.4.1",
  org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.e4.core.contexts;bundle-version="1.12.500",

--- a/de.tonsias.delta.view.ui.test/pom.xml
+++ b/de.tonsias.delta.view.ui.test/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui.test</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
+++ b/de.tonsias.delta.view.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DeltaViewUI
 Bundle-SymbolicName: de.tonsias.delta.view.ui
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: de.tonsias.delta.view.ui;x-friends:="de.tonsias.delta.vi
  ew.ui.test",de.tonsias.delta.view.ui.tree;x-friends:="de.tonsias.delta.
  view.ui.test"
@@ -18,8 +18,8 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="2.4.200.v20240
  jakarta.annotation-api,
  de.tonsias.basis.osgi,
  org.osgi.service.event;bundle-version="1.4.1",
- de.tonsias.delta.view.logic;bundle-version="0.2.0",
- de.tonsias.basis.icon;bundle-version="0.2.0"
+ de.tonsias.delta.view.logic;bundle-version="0.3.0",
+ de.tonsias.basis.icon;bundle-version="0.3.0"
 Automatic-Module-Name: de.tonsias.delta.view.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-24

--- a/de.tonsias.delta.view.ui/pom.xml
+++ b/de.tonsias.delta.view.ui/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>de.tonsias.delta.view.ui</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>de.tonsias</groupId>
 	<artifactId>de.tonsias.parent</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Tonsias</name>
@@ -69,7 +69,7 @@
 						<artifact>
 							<groupId>de.tonsias</groupId>
 							<artifactId>target-platform</artifactId>
-							<version>0.2.0</version>
+							<version>0.3.0-SNAPSHOT</version>
 						</artifact>
 					</target>
 					<!--

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>de.tonsias</groupId>
 		<artifactId>de.tonsias.parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>target-platform</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>eclipse-target-definition</packaging>
 </project>


### PR DESCRIPTION
Nach dem Tag `v0.2.0` geht `main` zurueck auf einen Snapshot - derselbe Schritt, der auf `v0.1.0` folgte (`chore post-release-bump: set the reactor to 0.2.0-SNAPSHOT`).

- `tycho-versions-plugin:set-version` auf `0.3.0-SNAPSHOT`, alle 38 Dateien. Das `version`-Attribut in `tonsias.product` stand auf `0.2.0` und damit auf dem alten Wert, wurde also nicht uebersprungen - es steht jetzt auf `0.3.0.qualifier`.
- Der `Unreleased`-Abschnitt im Changelog sagt wieder, worauf der Reaktor zulaeuft.

Kein Produktionscode. `.\build.ps1` gruen, 588 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)